### PR TITLE
Add QC DB schema and connection.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         mysql-version: ["5.7", "8.0"]
     
     services:
-      mysql:
+      mysql-mlwh:
         image: mysql:${{ matrix.mysql-version }}
         ports:
           - 3306:3306
@@ -46,7 +46,22 @@ jobs:
           MYSQL_USER: "test"
           MYSQL_PASSWORD: "test"
           MYSQL_DATABASE: "mlwarehouse"
-    
+      mysql-qcdb:
+        image: mysql:${{ matrix.mysql-version }}
+        ports:
+          - 3307:3307
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+        env:
+          MYSQL_RANDOM_ROOT_PASSWORD: yes
+          MYSQL_TCP_PORT: 3307
+          MYSQL_USER: "test"
+          MYSQL_PASSWORD: "test"
+          MYSQL_DATABASE: "langqc"
+
     steps:
       - uses: actions/checkout@v3
       

--- a/lang_qc/db/qc_connection.py
+++ b/lang_qc/db/qc_connection.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2022 Genome Research Ltd.
+#
+# Author: Adam Blanchet <ab59@sanger.ac.uk>
+#
+# This file is part of npg_langqc.
+#
+# npg_langqc is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
+config = {"QCDB_URL": os.environ.get("QCDB_URL"), "TEST": os.environ.get("LANGQC_MODE")}
+
+if config["TEST"]:
+    config["QCDB_URL"] = "sqlite+pysqlite:///:memory:"
+
+if config["QCDB_URL"] is None or config["QCDB_URL"] == "":
+    raise Exception(
+        "ENV['QCDB_URL'] must be set with a database URL, or LANGQC_MODE must be set for testing."
+    )
+
+engine = create_engine(config["QCDB_URL"], future=True, echo=True)
+session_factory: sessionmaker = sessionmaker(engine, expire_on_commit=False)
+
+
+def get_qc_db() -> Session:
+    """Get QC DB connection"""
+    db = session_factory()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/lang_qc/db/qc_schema.py
+++ b/lang_qc/db/qc_schema.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2022 Genome Research Ltd.
+#
+# Author: Adam Blanchet <ab59@sanger.ac.uk>
+#
+# This file is part of npg_langqc.
+#
+# npg_langqc is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+from sqlalchemy import CHAR, Column, DateTime, ForeignKeyConstraint, Index, JSON, String, Text, text
+from sqlalchemy.dialects.mysql import BIGINT, INTEGER, TINYINT
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class QcStateDict(Base):
+    __tablename__ = 'qc_state_dict'
+
+    id_qc_state_dict = Column(INTEGER, primary_key=True)
+    state = Column(String(255), nullable=False, unique=True)
+    outcome = Column(TINYINT)
+
+    qc_state = relationship('QcState', back_populates='qc_state_dict')
+    qc_state_hist = relationship('QcStateHist', back_populates='qc_state_dict')
+
+
+class QcType(Base):
+    __tablename__ = 'qc_type'
+
+    id_qc_type = Column(INTEGER, primary_key=True)
+    qc_type = Column(String(10), nullable=False, unique=True)
+    description = Column(String(255), nullable=False)
+
+    qc_state = relationship('QcState', back_populates='qc_type')
+    qc_state_hist = relationship('QcStateHist', back_populates='qc_type')
+
+
+class SeqPlatform(Base):
+    __tablename__ = 'seq_platform'
+
+    id_seq_platform = Column(INTEGER, primary_key=True)
+    name = Column(String(10), nullable=False, unique=True)
+    description = Column(String(255), nullable=False)
+    iscurrent = Column(TINYINT(1), nullable=False, server_default=text("'1'"))
+
+    seq_product = relationship('SeqProduct', back_populates='seq_platform')
+
+
+class SubProductAttr(Base):
+    __tablename__ = 'sub_product_attr'
+
+    id_attr = Column(INTEGER, primary_key=True)
+    attr_name = Column(String(20), nullable=False, unique=True)
+    description = Column(String(255), nullable=False)
+
+    sub_product = relationship('SubProduct', foreign_keys='[SubProduct.id_attr_one]', back_populates='sub_product_attr')
+    sub_product_ = relationship('SubProduct', foreign_keys='[SubProduct.id_attr_two]', back_populates='sub_product_attr_')
+
+
+class User(Base):
+    __tablename__ = 'user'
+
+    id_user = Column(INTEGER, primary_key=True)
+    username = Column(String(12), nullable=False, unique=True)
+    iscurrent = Column(TINYINT(1), nullable=False, server_default=text("'1'"))
+    date_created = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'), comment='Datetime the user record was created')
+    date_updated = Column(DateTime, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'), comment='Datetime the user record was created or changed')
+
+    annotation = relationship('Annotation', back_populates='user')
+    qc_state = relationship('QcState', back_populates='user')
+    qc_state_hist = relationship('QcStateHist', back_populates='user')
+
+
+class Annotation(Base):
+    __tablename__ = 'annotation'
+    __table_args__ = (
+        ForeignKeyConstraint(['id_user'], ['user.id_user'], name='fk_annotation_user'),
+    )
+
+    id_annotation = Column(BIGINT, primary_key=True)
+    id_user = Column(INTEGER, nullable=False, index=True)
+    comment = Column(Text, nullable=False)
+    date_created = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'), comment='Datetime this record was created')
+    qc_specific = Column(TINYINT(1), server_default=text("'0'"))
+
+    user = relationship('User', back_populates='annotation')
+    product_annotation = relationship('ProductAnnotation', back_populates='annotation')
+
+
+class SeqProduct(Base):
+    __tablename__ = 'seq_product'
+    __table_args__ = (
+        ForeignKeyConstraint(['id_seq_platform'], ['seq_platform.id_seq_platform'], name='fk_subproduct_seq_pl'),
+    )
+
+    id_seq_product = Column(BIGINT, primary_key=True)
+    id_product = Column(CHAR(64), nullable=False, unique=True)
+    id_seq_platform = Column(INTEGER, nullable=False, index=True)
+    has_seq_data = Column(TINYINT(1), server_default=text("'1'"))
+
+    seq_platform = relationship('SeqPlatform', back_populates='seq_product')
+    product_annotation = relationship('ProductAnnotation', back_populates='seq_product')
+    product_layout = relationship('ProductLayout', back_populates='seq_product')
+    qc_state = relationship('QcState', back_populates='seq_product')
+    qc_state_hist = relationship('QcStateHist', back_populates='seq_product')
+
+
+class SubProduct(Base):
+    __tablename__ = 'sub_product'
+    __table_args__ = (
+        ForeignKeyConstraint(['id_attr_one'], ['sub_product_attr.id_attr'], name='fk_subproduct_attr1'),
+        ForeignKeyConstraint(['id_attr_two'], ['sub_product_attr.id_attr'], name='fk_subproduct_attr2')
+    )
+
+    id_sub_product = Column(BIGINT, primary_key=True)
+    id_attr_one = Column(INTEGER, nullable=False, index=True)
+    value_attr_one = Column(String(20), nullable=False, index=True)
+    id_attr_two = Column(INTEGER, nullable=False, index=True)
+    value_attr_two = Column(String(20), nullable=False, index=True)
+    properties = Column(JSON, nullable=False)
+    properties_digest = Column(CHAR(64), nullable=False, unique=True)
+    tags = Column(String(255), index=True)
+
+    sub_product_attr = relationship('SubProductAttr', foreign_keys=[id_attr_one], back_populates='sub_product')
+    sub_product_attr_ = relationship('SubProductAttr', foreign_keys=[id_attr_two], back_populates='sub_product_')
+    product_layout = relationship('ProductLayout', back_populates='sub_product')
+
+
+class ProductAnnotation(Base):
+    __tablename__ = 'product_annotation'
+    __table_args__ = (
+        ForeignKeyConstraint(['id_annotation'], ['annotation.id_annotation'], name='fk_pr_annotation_annotation'),
+        ForeignKeyConstraint(['id_seq_product'], ['seq_product.id_seq_product'], name='fk_pr_annotation_product')
+    )
+
+    id_product_annotation = Column(BIGINT, primary_key=True)
+    id_annotation = Column(BIGINT, nullable=False, index=True)
+    id_seq_product = Column(BIGINT, nullable=False, index=True)
+
+    annotation = relationship('Annotation', back_populates='product_annotation')
+    seq_product = relationship('SeqProduct', back_populates='product_annotation')
+
+
+class ProductLayout(Base):
+    __tablename__ = 'product_layout'
+    __table_args__ = (
+        ForeignKeyConstraint(['id_seq_product'], ['seq_product.id_seq_product'], name='fk_product_layout_seqpr'),
+        ForeignKeyConstraint(['id_sub_product'], ['sub_product.id_sub_product'], name='fk_product_layout_subpr'),
+        Index('unique_product_layout', 'id_seq_product', 'id_sub_product', unique=True)
+    )
+
+    id_product_layout = Column(BIGINT, primary_key=True)
+    id_seq_product = Column(BIGINT, nullable=False)
+    id_sub_product = Column(BIGINT, nullable=False, index=True)
+
+    seq_product = relationship('SeqProduct', back_populates='product_layout')
+    sub_product = relationship('SubProduct', back_populates='product_layout')
+
+
+class QcState(Base):
+    __tablename__ = 'qc_state'
+    __table_args__ = (
+        ForeignKeyConstraint(['id_qc_state_dict'], ['qc_state_dict.id_qc_state_dict'], name='fk_qc_state_state'),
+        ForeignKeyConstraint(['id_qc_type'], ['qc_type.id_qc_type'], name='fk_qc_type'),
+        ForeignKeyConstraint(['id_seq_product'], ['seq_product.id_seq_product'], name='fk_qc_state_product'),
+        ForeignKeyConstraint(['id_user'], ['user.id_user'], name='fk_qc_state_user'),
+        Index('unique_qc_state', 'id_seq_product', 'id_qc_type', unique=True)
+    )
+
+    id_qc_state = Column(BIGINT, primary_key=True)
+    id_seq_product = Column(BIGINT, nullable=False)
+    id_user = Column(INTEGER, nullable=False, index=True)
+    id_qc_state_dict = Column(INTEGER, nullable=False, index=True)
+    id_qc_type = Column(INTEGER, nullable=False, index=True)
+    created_by = Column(String(20), nullable=False)
+    is_preliminary = Column(TINYINT(1), server_default=text("'1'"))
+    date_created = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'), comment='Datetime this record was created')
+    date_updated = Column(DateTime, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'), comment='Datetime this record was created or changed')
+
+    qc_state_dict = relationship('QcStateDict', back_populates='qc_state')
+    qc_type = relationship('QcType', back_populates='qc_state')
+    seq_product = relationship('SeqProduct', back_populates='qc_state')
+    user = relationship('User', back_populates='qc_state')
+
+
+class QcStateHist(Base):
+    __tablename__ = 'qc_state_hist'
+    __table_args__ = (
+        ForeignKeyConstraint(['id_qc_state_dict'], ['qc_state_dict.id_qc_state_dict'], name='fk_qc_stateh_state'),
+        ForeignKeyConstraint(['id_qc_type'], ['qc_type.id_qc_type'], name='fk_qc_stateh_type'),
+        ForeignKeyConstraint(['id_seq_product'], ['seq_product.id_seq_product'], name='fk_qc_stateh_product'),
+        ForeignKeyConstraint(['id_user'], ['user.id_user'], name='fk_qc_stateh_user')
+    )
+
+    id_qc_state_hist = Column(BIGINT, primary_key=True)
+    id_seq_product = Column(BIGINT, nullable=False, index=True)
+    id_user = Column(INTEGER, nullable=False, index=True)
+    id_qc_state_dict = Column(INTEGER, nullable=False, index=True)
+    id_qc_type = Column(INTEGER, nullable=False, index=True)
+    created_by = Column(String(20), nullable=False)
+    date_created = Column(DateTime, nullable=False, comment='Datetime the original record was created')
+    date_updated = Column(DateTime, nullable=False, comment='Datetime the original record was created or changed')
+    is_preliminary = Column(TINYINT(1), server_default=text("'1'"))
+
+    qc_state_dict = relationship('QcStateDict', back_populates='qc_state_hist')
+    qc_type = relationship('QcType', back_populates='qc_state_hist')
+    seq_product = relationship('SeqProduct', back_populates='qc_state_hist')
+    user = relationship('User', back_populates='qc_state_hist')

--- a/poetry.lock
+++ b/poetry.lock
@@ -79,7 +79,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "cffi"
-version = "1.15.0"
+version = "1.15.1"
 description = "Foreign Function Interface for Python calling C code."
 category = "main"
 optional = false
@@ -242,6 +242,18 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "inflect"
+version = "5.6.0"
+description = "Correctly generate plurals, singular nouns, ordinals, indefinite articles; convert numbers to words"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pygments", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -525,6 +537,29 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "sqlacodegen"
+version = "3.0.0rc1"
+description = "Automatic model code generator for SQLAlchemy"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+develop = false
+
+[package.dependencies]
+inflect = ">=4.0.0"
+SQLAlchemy = ">=1.4.0"
+
+[package.extras]
+citext = ["sqlalchemy-citext (>=1.7.0)"]
+test = ["pytest", "pytest-cov", "psycopg2-binary", "mysql-connector-python"]
+
+[package.source]
+type = "git"
+url = "http://github.com/agronholm/sqlacodegen.git"
+reference = "3.0.0rc1"
+resolved_reference = "c673bb24446c6ed1401a48fe56a663b0a0616cee"
+
+[[package]]
 name = "sqlalchemy"
 version = "1.4.39"
 description = "Database Abstraction Library"
@@ -692,7 +727,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "9e1e8d40a7bcb60ce521cc27d52b80da72cf17525db71d5d6a2afbcd642ff8c9"
+content-hash = "f00445e07bd4304b2ab0d1c2566ddef36b02fa13ecb3b31e72898f4a7e38964e"
 
 [metadata.files]
 anyio = [
@@ -741,56 +776,70 @@ certifi = [
     {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
 ]
 cffi = [
-    {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
-    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0"},
-    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:41d45de54cd277a7878919867c0f08b0cf817605e4eb94093e7516505d3c8d14"},
-    {file = "cffi-1.15.0-cp27-cp27m-win32.whl", hash = "sha256:4a306fa632e8f0928956a41fa8e1d6243c71e7eb59ffbd165fc0b41e316b2474"},
-    {file = "cffi-1.15.0-cp27-cp27m-win_amd64.whl", hash = "sha256:e7022a66d9b55e93e1a845d8c9eba2a1bebd4966cd8bfc25d9cd07d515b33fa6"},
-    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:14cd121ea63ecdae71efa69c15c5543a4b5fbcd0bbe2aad864baca0063cecf27"},
-    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d4d692a89c5cf08a8557fdeb329b82e7bf609aadfaed6c0d79f5a449a3c7c023"},
-    {file = "cffi-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2"},
-    {file = "cffi-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91ec59c33514b7c7559a6acda53bbfe1b283949c34fe7440bcf917f96ac0723e"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f5c7150ad32ba43a07c4479f40241756145a1f03b43480e058cfd862bf5041c7"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abb9a20a72ac4e0fdb50dae135ba5e77880518e742077ced47eb1499e29a443c"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a5263e363c27b653a90078143adb3d076c1a748ec9ecc78ea2fb916f9b861962"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f54a64f8b0c8ff0b64d18aa76675262e1700f3995182267998c31ae974fbc382"},
-    {file = "cffi-1.15.0-cp310-cp310-win32.whl", hash = "sha256:c21c9e3896c23007803a875460fb786118f0cdd4434359577ea25eb556e34c55"},
-    {file = "cffi-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e069f72d497312b24fcc02073d70cb989045d1c91cbd53979366077959933e0"},
-    {file = "cffi-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:64d4ec9f448dfe041705426000cc13e34e6e5bb13736e9fd62e34a0b0c41566e"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2756c88cbb94231c7a147402476be2c4df2f6078099a6f4a480d239a8817ae39"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b96a311ac60a3f6be21d2572e46ce67f09abcf4d09344c49274eb9e0bf345fc"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75e4024375654472cc27e91cbe9eaa08567f7fbdf822638be2814ce059f58032"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:59888172256cac5629e60e72e86598027aca6bf01fa2465bdb676d37636573e8"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:27c219baf94952ae9d50ec19651a687b826792055353d07648a5695413e0c605"},
-    {file = "cffi-1.15.0-cp36-cp36m-win32.whl", hash = "sha256:4958391dbd6249d7ad855b9ca88fae690783a6be9e86df65865058ed81fc860e"},
-    {file = "cffi-1.15.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc"},
-    {file = "cffi-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:06c48159c1abed75c2e721b1715c379fa3200c7784271b3c46df01383b593636"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c2051981a968d7de9dd2d7b87bcb9c939c74a34626a6e2f8181455dd49ed69e4"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91d77d2a782be4274da750752bb1650a97bfd8f291022b379bb8e01c66b4e96b"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45db3a33139e9c8f7c09234b5784a5e33d31fd6907800b316decad50af323ff2"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:263cc3d821c4ab2213cbe8cd8b355a7f72a8324577dc865ef98487c1aeee2bc7"},
-    {file = "cffi-1.15.0-cp37-cp37m-win32.whl", hash = "sha256:17771976e82e9f94976180f76468546834d22a7cc404b17c22df2a2c81db0c66"},
-    {file = "cffi-1.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3415c89f9204ee60cd09b235810be700e993e343a408693e80ce7f6a40108029"},
-    {file = "cffi-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4238e6dab5d6a8ba812de994bbb0a79bddbdf80994e4ce802b6f6f3142fcc880"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0808014eb713677ec1292301ea4c81ad277b6cdf2fdd90fd540af98c0b101d20"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57e9ac9ccc3101fac9d6014fba037473e4358ef4e89f8e181f8951a2c0162024"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b6c2ea03845c9f501ed1313e78de148cd3f6cad741a75d43a29b43da27f2e1e"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:10dffb601ccfb65262a27233ac273d552ddc4d8ae1bf93b21c94b8511bffe728"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:786902fb9ba7433aae840e0ed609f45c7bcd4e225ebb9c753aa39725bb3e6ad6"},
-    {file = "cffi-1.15.0-cp38-cp38-win32.whl", hash = "sha256:da5db4e883f1ce37f55c667e5c0de439df76ac4cb55964655906306918e7363c"},
-    {file = "cffi-1.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:181dee03b1170ff1969489acf1c26533710231c58f95534e3edac87fff06c443"},
-    {file = "cffi-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:45e8636704eacc432a206ac7345a5d3d2c62d95a507ec70d62f23cd91770482a"},
-    {file = "cffi-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:31fb708d9d7c3f49a60f04cf5b119aeefe5644daba1cd2a0fe389b674fd1de37"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6dc2737a3674b3e344847c8686cf29e500584ccad76204efea14f451d4cc669a"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74fdfdbfdc48d3f47148976f49fab3251e550a8720bebc99bf1483f5bfb5db3e"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f7d084648d77af029acb79a0ff49a0ad7e9d09057a9bf46596dac9514dc07df"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef1f279350da2c586a69d32fc8733092fd32cc8ac95139a00377841f59a3f8d8"},
-    {file = "cffi-1.15.0-cp39-cp39-win32.whl", hash = "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a"},
-    {file = "cffi-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139"},
-    {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
 ]
 charset-normalizer = [
     {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
@@ -939,6 +988,10 @@ httptools = [
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+inflect = [
+    {file = "inflect-5.6.0-py3-none-any.whl", hash = "sha256:967d6db69932bac9f1977b8f2dd131a59147f4b56134cfc74a3f44e5adb65223"},
+    {file = "inflect-5.6.0.tar.gz", hash = "sha256:a0612e7bba1028bb7efa121bf8f012aeda9355252d01b257057fa2a8f5859cef"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1177,6 +1230,7 @@ sniffio = [
     {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
     {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
 ]
+sqlacodegen = []
 sqlalchemy = [
     {file = "SQLAlchemy-1.4.39-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:4770eb3ba69ec5fa41c681a75e53e0e342ac24c1f9220d883458b5596888e43a"},
     {file = "SQLAlchemy-1.4.39-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:752ef2e8dbaa3c5d419f322e3632f00ba6b1c3230f65bc97c2ff5c5c6c08f441"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,11 @@ black = "^22.3.0"
 flake8 = "^4.0.1"
 pytest = "^7.1.1"
 fastapi = { extras = ["all"], version = "^0.78.0" }
+sqlacodegen = { git = "http://github.com/agronholm/sqlacodegen.git", tag="3.0.0rc1" }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+extend-exclude = "lang_qc/db/qc_schema.py"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,14 @@ import os
 
 import pytest
 from fastapi.testclient import TestClient
-from ml_warehouse.schema import Base
+from ml_warehouse.schema import Base as MlwhBase
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker, Session
 
 from lang_qc.main import app
 from lang_qc.db.mlwh_connection import get_mlwh_db
+from lang_qc.db.qc_connection import get_qc_db
+from lang_qc.db.qc_schema import Base as QcBase
 
 test_ini = os.path.join(os.path.dirname(__file__), "testdb.ini")
 
@@ -22,19 +24,19 @@ def config() -> configparser.ConfigParser:
     return test_config
 
 
-def mysql_url(config: configparser.ConfigParser):
+def mlwh_mysql_url(config: configparser.ConfigParser):
     """Returns a MySQL URL configured through an ini file.
 
     The keys and values are:
 
-    [MySQL]
-    user       = <database user, defaults to "mlwh">
+    [MySQL MLWH]
+    user       = <database user, defaults to "test">
     password   = <database password, defaults to empty i.e. "">
     ip_address = <database IP address, defaults to "127.0.0.1">
     port       = <database port, defaults to 3306>
-    schema     = <database schema, defaults to "mlwh">
+    schema     = <database schema, defaults to "mlwarehouse">
     """
-    section = "MySQL"
+    section = "MySQL MLWH"
 
     if section not in config.sections():
         raise configparser.Error(
@@ -43,11 +45,44 @@ def mysql_url(config: configparser.ConfigParser):
             "tests on a {} database".format(section, section)
         )
     connection_conf = config[section]
-    user = connection_conf.get("user", "mlwh")
+    user = connection_conf.get("user", "test")
     password = connection_conf.get("password", "")
     ip_address = connection_conf.get("ip_address", "127.0.0.1")
     port = connection_conf.get("port", "3306")
-    schema = connection_conf.get("schema", "mlwh")
+    schema = connection_conf.get("schema", "mlwarehouse")
+
+    return (
+        f"mysql+pymysql://{user}:{password}@"
+        f"{ip_address}:{port}/{schema}?charset=utf8mb4"
+    )
+
+
+def qcdb_mysql_url(config: configparser.ConfigParser):
+    """Returns a MySQL URL configured through an ini file.
+
+    The keys and values are:
+
+    [MySQL QCDB]
+    user       = <database user, defaults to "test">
+    password   = <database password, defaults to empty i.e. "">
+    ip_address = <database IP address, defaults to "127.0.0.1">
+    port       = <database port, defaults to 3307>
+    schema     = <database schema, defaults to "langqc">
+    """
+    section = "MySQL QCDB"
+
+    if section not in config.sections():
+        raise configparser.Error(
+            "The {} configuration section is missing. "
+            "You need to fill this in before running "
+            "tests on a {} database".format(section, section)
+        )
+    connection_conf = config[section]
+    user = connection_conf.get("user", "test")
+    password = connection_conf.get("password", "")
+    ip_address = connection_conf.get("ip_address", "127.0.0.1")
+    port = connection_conf.get("port", "3307")
+    schema = connection_conf.get("schema", "langqc")
 
     return (
         f"mysql+pymysql://{user}:{password}@"
@@ -57,7 +92,7 @@ def mysql_url(config: configparser.ConfigParser):
 
 @pytest.fixture(scope="function", name="mlwhdb_test_sessionfactory")
 def create_mlwhdb_test_sessionfactory(config):
-    engine = create_engine(mysql_url(config), future=True)
+    engine = create_engine(mlwh_mysql_url(config), future=True)
 
     TestingSessionLocal = sessionmaker(bind=engine)
 
@@ -69,14 +104,29 @@ def create_mlwhdb_test_sessionfactory(config):
         conn.execute(text("SET foreign_key_checks=0;"))
         conn.commit()
     # Drop all tables and then create them to make it easier to test locally too.
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
+    MlwhBase.metadata.drop_all(bind=engine)
+    MlwhBase.metadata.create_all(bind=engine)
+
+    return TestingSessionLocal
+
+
+@pytest.fixture(scope="function", name="qcdb_test_sessionfactory")
+def create_qcdb_test_sessionfactory(config):
+    engine = create_engine(qcdb_mysql_url(config), future=True)
+
+    TestingSessionLocal = sessionmaker(bind=engine)
+
+    # Drop all tables and then create then to make it easier to test locally too.
+    QcBase.metadata.drop_all(bind=engine)
+    QcBase.metadata.create_all(bind=engine)
 
     return TestingSessionLocal
 
 
 @pytest.fixture(scope="function", name="test_client")
-def create_test_client(config, mlwhdb_test_sessionfactory) -> TestClient:
+def create_test_client(
+    config, mlwhdb_test_sessionfactory, qcdb_test_sessionfactory
+) -> TestClient:
     def override_get_mlwh_db():
         try:
             db: Session = mlwhdb_test_sessionfactory()
@@ -84,8 +134,15 @@ def create_test_client(config, mlwhdb_test_sessionfactory) -> TestClient:
         finally:
             db.close()
 
-    app.dependency_overrides[get_mlwh_db] = override_get_mlwh_db
+    def override_get_qc_db():
+        try:
+            db: Session = qcdb_test_sessionfactory()
+            yield db
+        finally:
+            db.close()
 
+    app.dependency_overrides[get_mlwh_db] = override_get_mlwh_db
+    app.dependency_overrides[get_qc_db] = override_get_qc_db
     client = TestClient(app)
 
     return client

--- a/tests/testdb.ini
+++ b/tests/testdb.ini
@@ -1,6 +1,6 @@
 # Credentials to be used for unit tests.
 #
-# GitHub Actions CI should set up a MySQL service matching these credentials.
+# GitHub Actions CI should set up two MySQL services matching these credentials.
 # If you are running tests on your local development machine, you can start a
 # suitable Docker container like so:
 #
@@ -11,9 +11,23 @@
 #     -e MYSQL_PASSWORD=test \
 #     -e MYSQL_DATABASE=mlwarehouse "mysql:$MYSQL_VERSION"
 #
-[MySQL]
+# docker run --network host -d \
+#     -e MYSQL_RANDOM_ROOT_PASSWORD=yes \
+#     -e MYSQL_TCP_PORT=3307 \
+#     -e MYSQL_USER=test \
+#     -e MYSQL_PASSWORD=test \
+#     -e MYSQL_DATABASE=langqc "mysql:$MYSQL_VERSION"
+
+[MySQL MLWH]
 user = test
 password = test
 ip_address = 127.0.0.1
 port = 3306
 schema = mlwarehouse
+
+[MySQL QCDB]
+user = test
+password = test
+ip_address = 127.0.0.1
+port = 3307
+schema = langqc


### PR DESCRIPTION
`lang_qc/db/qc_connection.py` is generated by `sqlacodegen`([version 3.0.0rc1](https://github.com/agronholm/sqlacodegen/releases/tag/3.0.0rc1)), with the copyright notice added on top. `sqlacodegen` was run against the schema defined in #4, specifically from commit <https://github.com/wtsi-npg/npg_langqc/pull/4/commits/e381b672b99385e02add8b76a9fb4412d561fa5e>, deployed on a MySQL 8.0 container. The file isn't formatted after generation, so flake8 and black are set to ignore it.

Two options for this file:
- use it as a starting point to define the schema with SQLAlchemy models. We could then customise the SQLAlchemy models with relationships that `sqlacodegen` doesn't reflect in the most convenient way, without needing to maintain an extra layer on top of the `sqlacodegen` output. We could also then manage schema migrations with [alembic](https://github.com/sqlalchemy/alembic). The downside is that it may be slightly harder to make bindings for other languages like Perl.
- keep reflecting the SQLAlchemy models from the DB every time there is a change. It would be simpler for people who do not want to use Python to interact with the DB, but would make it more complicated for us to add custom functions/attributes to the SQLAlchemy model (wtsi-npg/ml-warehouse-python uses a custom script which invokes `sqlacodegen` and then adds decorators to the generated file).