### PR TITLE
QC status endpoint(s)

### DIFF
--- a/lang_qc/endpoints/qc_state.py
+++ b/lang_qc/endpoints/qc_state.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2022 Genome Research Ltd.
+#
+# Author: Adam Blanchet <ab59@sanger.ac.uk>
+#
+# This file is part of npg_langqc.
+#
+# npg_langqc is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from product_id.main import PacBioWell
+from sqlalchemy import and_, select
+from sqlalchemy.orm import Session
+
+from lang_qc.db.qc_connection import get_qc_db
+from lang_qc.db.qc_schema import (
+    ProductLayout,
+    QcState,
+    QcStateDict,
+    QcStateHist,
+    QcType,
+    SeqPlatform,
+    SeqProduct,
+    SubProduct,
+    SubProductAttr,
+    User,
+)
+from lang_qc.models.inbox_models import QcStatus
+
+
+router = APIRouter()
+
+
+def get_qc_state_for_well(
+    run_name: str, well_label: str, qcdb_session: Session
+) -> Optional[QcState]:
+    """Get a QcState from a well."""
+
+    return qcdb_session.execute(
+        select(QcState)
+        .join(SeqProduct)
+        .join(ProductLayout)
+        .join(SubProduct)
+        .where(
+            and_(
+                SubProduct.value_attr_one == run_name,
+                SubProduct.value_attr_two == well_label,
+            )
+        )
+    ).scalar_one_or_none()
+
+
+def get_seq_product_for_well(run_name: str, well_label: str, qcdb_session: Session):
+    """Get a SeqProduct from a well."""
+
+    return (
+        qcdb_session.execute(
+            select(SeqProduct)
+            .join(ProductLayout)
+            .join(SubProduct)
+            .where(
+                and_(
+                    SubProduct.value_attr_one == run_name,
+                    SubProduct.value_attr_two == well_label,
+                )
+            )
+        )
+        .scalars()
+        .one_or_none()
+    )
+
+
+def create_id_product(run_name, well_label):
+    return PacBioWell(run_name=run_name, well_label=well_label)
+
+
+def create_well_properties(run_name, well_label):
+    return json.dumps({"run_name": run_name, "well_label": well_label})
+
+
+def create_well_properties_digest(run_name, well_label):
+    return hash(frozenset(create_well_properties(run_name, well_label)))
+
+
+@dataclass
+class UserWrapper:
+    name: str
+
+
+def construct_seq_product_for_well(
+    run_name: str, well_label: str, qcdb_session: Session
+):
+
+    seq_platform = qcdb_session.execute(
+        select(SeqPlatform).where(SeqPlatform.name == "PacBio")
+    ).scalar_one_or_none()
+    run_name_product_attr = qcdb_session.execute(
+        select(SubProductAttr).where(SubProductAttr.attr_name == "run_name")
+    ).scalar_one_or_none()
+    well_label_product_attr = qcdb_session.execute(
+        select(SubProductAttr).where(SubProductAttr.attr_name == "well_label")
+    ).scalar_one_or_none()
+
+    qcdb_session.add(
+        SeqProduct(
+            id_product=create_id_product(run_name, well_label),
+            seq_platform=seq_platform,
+            product_layout=[
+                ProductLayout(
+                    sub_product=SubProduct(
+                        sub_product_attr=run_name_product_attr,
+                        sub_product_attr_=well_label_product_attr,
+                        value_attr_one=run_name,
+                        value_attr_two=well_label,
+                        properties=create_well_properties(run_name, well_label),
+                        properties_digest=create_well_properties_digest(
+                            run_name, well_label
+                        ),
+                    )
+                )
+            ],
+        )
+    )
+
+    qcdb_session.commit()
+
+
+def update_qc_state(
+    qc_status_post: QcStatus, qc_state_db: QcState, qcdb_session: Session
+):
+
+    user = qcdb_session.execute(
+        select(User).where(User.username == qc_status_post.user)
+    ).scalar_one_or_none()
+    qc_state_db.user = user
+    qc_state_db.date_updated = datetime.now()
+    qc_state_db.id_qc_state_dict = qcdb_session.execute(
+        select(QcStateDict.id_qc_state_dict).where(
+            QcStateDict.state == qc_status_post.qc_state
+        )
+    ).one_or_none()[0]
+    qc_state_db.id_qc_type = qcdb_session.execute(
+        select(QcType.id_qc_type).where(QcType.qc_type == qc_status_post.qc_type)
+    ).one_or_none()[0]
+    qc_state_db.created_by = "LangQC"
+    qc_state_db.is_preliminary = qc_status_post.is_preliminary
+
+
+@router.post(
+    "/run/{run_name}/well/{well_label}/qc_assign", tags=["Well level QC operations"]
+)
+def assign_qc_status(
+    run_name: str,
+    well_label: str,
+    qc_status: QcStatus,
+    qcdb_session: Session = Depends(get_qc_db),
+):
+
+    qc_state = get_qc_state_for_well(run_name, well_label, qcdb_session)
+
+    if qc_state is None:
+
+        seq_product = get_seq_product_for_well(run_name, well_label, qcdb_session)
+
+        if seq_product is None:
+            # Create a SeqProduct and related things for the well.
+            seq_product = construct_seq_product_for_well(
+                run_name, well_label, qcdb_session
+            )
+
+        user = qcdb_session.execute(
+            select(User).where(User.username == qc_status.user)
+        ).scalar_one_or_none()
+        if user is None:
+            user = User(username=qc_status.user, iscurrent=True)
+
+        qc_type = qcdb_session.execute(
+            select(QcType).where(QcType.qc_type == "library")
+        ).scalar_one_or_none()
+        qc_state_dict = qcdb_session.execute(
+            select(QcStateDict).where(QcStateDict.state == qc_status.qc_state)
+        ).scalar_one_or_none()
+        qc_state = QcState(
+            created_by="LangQC",
+            is_preliminary=qc_status.is_preliminary,
+            qc_state_dict=qc_state_dict,
+            qc_type=qc_type,
+            seq_product=seq_product,
+            user=user,
+        )
+
+        qcdb_session.add(qc_state)
+        qcdb_session.commit()
+
+    else:
+        # Create a historical record
+        historical_record = QcStateHist(
+            id_seq_product=qc_state.id_seq_product,
+            id_qc_type=qc_state.id_qc_type,
+            id_user=qc_state.id_user,
+            id_qc_state_dict=qc_state.id_qc_state_dict,
+            created_by=qc_state.created_by,
+            date_created=qc_state.date_created,
+            date_updated=qc_state.date_updated,
+            is_preliminary=qc_state.is_preliminary,
+        )
+
+        qcdb_session.add(historical_record)
+        qcdb_session.commit()
+
+        # Update the current record
+        update_qc_state(qc_status, qc_state, qcdb_session)
+        qcdb_session.merge(qc_state)
+        qcdb_session.commit()

--- a/lang_qc/endpoints/qc_state.py
+++ b/lang_qc/endpoints/qc_state.py
@@ -17,16 +17,17 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-from dataclasses import dataclass
 from datetime import datetime
 import json
 from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from ml_warehouse.schema import PacBioRunWellMetrics
 from product_id.main import PacBioWell
 from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 
+from lang_qc.db.mlwh_connection import get_mlwh_db
 from lang_qc.db.qc_connection import get_qc_db
 from lang_qc.db.qc_schema import (
     ProductLayout,
@@ -97,11 +98,6 @@ def create_well_properties_digest(run_name, well_label):
     return hash(frozenset(create_well_properties(run_name, well_label)))
 
 
-@dataclass
-class UserWrapper:
-    name: str
-
-
 def construct_seq_product_for_well(
     run_name: str, well_label: str, qcdb_session: Session
 ):
@@ -109,66 +105,108 @@ def construct_seq_product_for_well(
     seq_platform = qcdb_session.execute(
         select(SeqPlatform).where(SeqPlatform.name == "PacBio")
     ).scalar_one_or_none()
+    if seq_platform is None:
+        raise Exception("PacBio SeqPlatform is not in the QC database.")
+
     run_name_product_attr = qcdb_session.execute(
         select(SubProductAttr).where(SubProductAttr.attr_name == "run_name")
     ).scalar_one_or_none()
+    if run_name_product_attr is None:
+        raise Exception("PacBio run name SubProductAttr is not the QC database.")
+
     well_label_product_attr = qcdb_session.execute(
         select(SubProductAttr).where(SubProductAttr.attr_name == "well_label")
     ).scalar_one_or_none()
+    if well_label_product_attr is None:
+        raise Exception("PacBio well label SubProductAttr is not in the QC database.")
 
-    qcdb_session.add(
-        SeqProduct(
-            id_product=create_id_product(run_name, well_label),
-            seq_platform=seq_platform,
-            product_layout=[
-                ProductLayout(
-                    sub_product=SubProduct(
-                        sub_product_attr=run_name_product_attr,
-                        sub_product_attr_=well_label_product_attr,
-                        value_attr_one=run_name,
-                        value_attr_two=well_label,
-                        properties=create_well_properties(run_name, well_label),
-                        properties_digest=create_well_properties_digest(
-                            run_name, well_label
-                        ),
-                    )
+    seq_product = SeqProduct(
+        id_product=create_id_product(run_name, well_label),
+        seq_platform=seq_platform,
+        product_layout=[
+            ProductLayout(
+                sub_product=SubProduct(
+                    sub_product_attr=run_name_product_attr,
+                    sub_product_attr_=well_label_product_attr,
+                    value_attr_one=run_name,
+                    value_attr_two=well_label,
+                    properties=create_well_properties(run_name, well_label),
+                    properties_digest=create_well_properties_digest(
+                        run_name, well_label
+                    ),
                 )
-            ],
-        )
+            )
+        ],
     )
 
+    qcdb_session.add(seq_product)
     qcdb_session.commit()
+
+    return seq_product
 
 
 def update_qc_state(
     qc_status_post: QcStatus, qc_state_db: QcState, qcdb_session: Session
 ):
 
-    user = qcdb_session.execute(
-        select(User).where(User.username == qc_status_post.user)
-    ).scalar_one_or_none()
-    qc_state_db.user = user
-    qc_state_db.date_updated = datetime.now()
-    qc_state_db.id_qc_state_dict = qcdb_session.execute(
+    # Check that values are in the DB.
+    desired_qc_state_dict = qcdb_session.execute(
         select(QcStateDict.id_qc_state_dict).where(
             QcStateDict.state == qc_status_post.qc_state
         )
-    ).one_or_none()[0]
-    qc_state_db.id_qc_type = qcdb_session.execute(
+    ).one_or_none()
+    if desired_qc_state_dict is None:
+        raise Exception(
+            "Desired QC state is not in the QC database. It might not be allowed."
+        )
+
+    user = qcdb_session.execute(
+        select(User).where(User.username == qc_status_post.user)
+    ).scalar_one_or_none()
+    if user is None:
+        raise Exception(
+            "User has not been found in the QC database. Has it been registered?"
+        )
+
+    qc_type = qcdb_session.execute(
         select(QcType.id_qc_type).where(QcType.qc_type == qc_status_post.qc_type)
-    ).one_or_none()[0]
+    ).one_or_none()
+    if qc_type is None:
+        raise Exception("QC type is not in the QC database.")
+
+    qc_state_db.user = user
+    qc_state_db.date_updated = datetime.now()
+    qc_state_db.id_qc_state_dict = desired_qc_state_dict[0]
+    qc_state_db.id_qc_type = qc_type[0]
     qc_state_db.created_by = "LangQC"
     qc_state_db.is_preliminary = qc_status_post.is_preliminary
 
 
+def qc_status_json(db_qc_state: QcState) -> QcStatus:
+
+    return QcStatus(
+        user=db_qc_state.user.username,
+        date_created=db_qc_state.date_created,
+        date_updated=db_qc_state.date_updated,
+        qc_type=db_qc_state.qc_type.qc_type,
+        qc_type_description=db_qc_state.qc_type.description,
+        qc_state=db_qc_state.qc_state_dict.state,
+        is_preliminary=db_qc_state.is_preliminary,
+        created_by=db_qc_state.created_by,
+    )
+
+
 @router.post(
-    "/run/{run_name}/well/{well_label}/qc_assign", tags=["Well level QC operations"]
+    "/run/{run_name}/well/{well_label}/qc_assign",
+    tags=["Well level QC operations"],
+    response_model=QcStatus,
 )
 def assign_qc_status(
     run_name: str,
     well_label: str,
     qc_status: QcStatus,
     qcdb_session: Session = Depends(get_qc_db),
+    mlwhdb_session: Session = Depends(get_mlwh_db),
 ):
 
     qc_state = get_qc_state_for_well(run_name, well_label, qcdb_session)
@@ -178,6 +216,20 @@ def assign_qc_status(
         seq_product = get_seq_product_for_well(run_name, well_label, qcdb_session)
 
         if seq_product is None:
+            # Check that well exists in mlwh
+            mlwh_well = mlwhdb_session.execute(
+                select(PacBioRunWellMetrics).where(
+                    and_(
+                        PacBioRunWellMetrics.pac_bio_run_name == run_name,
+                        PacBioRunWellMetrics.well_label == well_label,
+                    )
+                )
+            ).scalar()
+            if mlwh_well is None:
+                raise HTTPException(
+                    status_code=400, detail="Well is not in the MLWH database."
+                )
+
             # Create a SeqProduct and related things for the well.
             seq_product = construct_seq_product_for_well(
                 run_name, well_label, qcdb_session
@@ -192,9 +244,19 @@ def assign_qc_status(
         qc_type = qcdb_session.execute(
             select(QcType).where(QcType.qc_type == "library")
         ).scalar_one_or_none()
+        if qc_type is None:
+            raise HTTPException(
+                status_code=400, detail="QC type is not in the QC database."
+            )
+
         qc_state_dict = qcdb_session.execute(
             select(QcStateDict).where(QcStateDict.state == qc_status.qc_state)
         ).scalar_one_or_none()
+        if qc_state_dict is None:
+            raise HTTPException(
+                status_code=400, detail="QC state dict is not in the QC database."
+            )
+
         qc_state = QcState(
             created_by="LangQC",
             is_preliminary=qc_status.is_preliminary,
@@ -224,6 +286,11 @@ def assign_qc_status(
         qcdb_session.commit()
 
         # Update the current record
-        update_qc_state(qc_status, qc_state, qcdb_session)
+        try:
+            update_qc_state(qc_status, qc_state, qcdb_session)
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=str(e))
         qcdb_session.merge(qc_state)
         qcdb_session.commit()
+
+    return qc_status_json(qc_state)

--- a/lang_qc/endpoints/qc_state.py
+++ b/lang_qc/endpoints/qc_state.py
@@ -17,188 +17,31 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-import json
-from typing import Optional
-
 from fastapi import APIRouter, Depends, HTTPException
 from ml_warehouse.schema import PacBioRunWellMetrics
-from product_id.main import PacBioWell
 from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 
 from lang_qc.db.mlwh_connection import get_mlwh_db
 from lang_qc.db.qc_connection import get_qc_db
 from lang_qc.db.qc_schema import (
-    ProductLayout,
     QcState,
     QcStateDict,
     QcStateHist,
     QcType,
-    SeqPlatform,
-    SeqProduct,
-    SubProduct,
-    SubProductAttr,
     User,
 )
 from lang_qc.models.inbox_models import QcStatus
 from lang_qc.models.qc_state_models import QcStatusAssignmentPostBody, QcClaimPostBody
-
+from lang_qc.util.qc_state_helpers import (
+    get_seq_product_for_well,
+    get_qc_state_for_well,
+    construct_seq_product_for_well,
+    qc_status_json,
+    update_qc_state,
+)
 
 router = APIRouter()
-
-
-def get_qc_state_for_well(
-    run_name: str, well_label: str, qcdb_session: Session
-) -> Optional[QcState]:
-    """Get a QcState from a well."""
-
-    return qcdb_session.execute(
-        select(QcState)
-        .join(SeqProduct)
-        .join(ProductLayout)
-        .join(SubProduct)
-        .where(
-            and_(
-                SubProduct.value_attr_one == run_name,
-                SubProduct.value_attr_two == well_label,
-            )
-        )
-    ).scalar_one_or_none()
-
-
-def get_seq_product_for_well(run_name: str, well_label: str, qcdb_session: Session):
-    """Get a SeqProduct from a well."""
-
-    return (
-        qcdb_session.execute(
-            select(SeqProduct)
-            .join(ProductLayout)
-            .join(SubProduct)
-            .where(
-                and_(
-                    SubProduct.value_attr_one == run_name,
-                    SubProduct.value_attr_two == well_label,
-                )
-            )
-        )
-        .scalars()
-        .one_or_none()
-    )
-
-
-def create_id_product(run_name, well_label):
-    return PacBioWell(run_name=run_name, well_label=well_label)
-
-
-def create_well_properties(run_name, well_label):
-    return json.dumps({"run_name": run_name, "well_label": well_label})
-
-
-def create_well_properties_digest(run_name, well_label):
-    return hash(frozenset(create_well_properties(run_name, well_label)))
-
-
-def construct_seq_product_for_well(
-    run_name: str, well_label: str, qcdb_session: Session
-):
-
-    seq_platform = qcdb_session.execute(
-        select(SeqPlatform).where(SeqPlatform.name == "PacBio")
-    ).scalar_one_or_none()
-    if seq_platform is None:
-        raise Exception("PacBio SeqPlatform is not in the QC database.")
-
-    run_name_product_attr = qcdb_session.execute(
-        select(SubProductAttr).where(SubProductAttr.attr_name == "run_name")
-    ).scalar_one_or_none()
-    if run_name_product_attr is None:
-        raise Exception("PacBio run name SubProductAttr is not the QC database.")
-
-    well_label_product_attr = qcdb_session.execute(
-        select(SubProductAttr).where(SubProductAttr.attr_name == "well_label")
-    ).scalar_one_or_none()
-    if well_label_product_attr is None:
-        raise Exception("PacBio well label SubProductAttr is not in the QC database.")
-
-    seq_product = SeqProduct(
-        id_product=create_id_product(run_name, well_label),
-        seq_platform=seq_platform,
-        product_layout=[
-            ProductLayout(
-                sub_product=SubProduct(
-                    sub_product_attr=run_name_product_attr,
-                    sub_product_attr_=well_label_product_attr,
-                    value_attr_one=run_name,
-                    value_attr_two=well_label,
-                    properties=create_well_properties(run_name, well_label),
-                    properties_digest=create_well_properties_digest(
-                        run_name, well_label
-                    ),
-                )
-            )
-        ],
-    )
-
-    qcdb_session.add(seq_product)
-    qcdb_session.commit()
-
-    return seq_product
-
-
-def update_qc_state(
-    qc_status_post: QcStatus, qc_state_db: QcState, qcdb_session: Session
-):
-
-    # Check that values are in the DB.
-    desired_qc_state_dict = qcdb_session.execute(
-        select(QcStateDict.id_qc_state_dict).where(
-            QcStateDict.state == qc_status_post.qc_state
-        )
-    ).one_or_none()
-    if desired_qc_state_dict is None:
-        raise Exception(
-            "Desired QC state is not in the QC database. It might not be allowed."
-        )
-
-    user = qcdb_session.execute(
-        select(User).where(User.username == qc_status_post.user)
-    ).scalar_one_or_none()
-    if user is None:
-        raise Exception(
-            "User has not been found in the QC database. Has it been registered?"
-        )
-
-    qc_type = qcdb_session.execute(
-        select(QcType.id_qc_type).where(QcType.qc_type == qc_status_post.qc_type)
-    ).one_or_none()
-    if qc_type is None:
-        raise Exception("QC type is not in the QC database.")
-
-    qc_state_db.user = user
-    qc_state_db.date_updated = datetime.now()
-    qc_state_db.id_qc_state_dict = desired_qc_state_dict[0]
-    qc_state_db.id_qc_type = qc_type[0]
-    qc_state_db.created_by = "LangQC"
-    qc_state_db.is_preliminary = qc_status_post.is_preliminary
-
-
-def qc_status_json(db_qc_state: QcState) -> QcStatus:
-
-    return QcStatus(
-        user=db_qc_state.user.username,
-        date_created=db_qc_state.date_created,
-        date_updated=db_qc_state.date_updated,
-        qc_type=db_qc_state.qc_type.qc_type,
-        qc_type_description=db_qc_state.qc_type.description,
-        qc_state=db_qc_state.qc_state_dict.state,
-        is_preliminary=db_qc_state.is_preliminary,
-        created_by=db_qc_state.created_by,
-    )
-
-
-def create_qc_state_for_well(run_name, well_label, qcdb_session):
-    """Create and insert a QcState for a well into the DB."""
 
 
 @router.post(
@@ -212,7 +55,7 @@ def claim_well(
     body: QcClaimPostBody,
     qcdb_session: Session = Depends(get_qc_db),
     mlwhdb_session: Session = Depends(get_mlwh_db),
-):
+) -> QcStatus:
 
     qc_state = get_qc_state_for_well(run_name, well_label, qcdb_session)
 
@@ -293,7 +136,7 @@ def assign_qc_status(
     qc_status: QcStatusAssignmentPostBody,
     qcdb_session: Session = Depends(get_qc_db),
     mlwhdb_session: Session = Depends(get_mlwh_db),
-):
+) -> QcStatus:
 
     qc_state = get_qc_state_for_well(run_name, well_label, qcdb_session)
 

--- a/lang_qc/endpoints/qc_state.py
+++ b/lang_qc/endpoints/qc_state.py
@@ -146,28 +146,27 @@ def assign_qc_status(
             detail="Cannot assign a state to a well which has not yet been claimed.",
         )
 
-    else:
-        # Create a historical record
-        historical_record = QcStateHist(
-            id_seq_product=qc_state.id_seq_product,
-            id_qc_type=qc_state.id_qc_type,
-            id_user=qc_state.id_user,
-            id_qc_state_dict=qc_state.id_qc_state_dict,
-            created_by=qc_state.created_by,
-            date_created=qc_state.date_created,
-            date_updated=qc_state.date_updated,
-            is_preliminary=qc_state.is_preliminary,
-        )
+    # Create a historical record
+    historical_record = QcStateHist(
+        id_seq_product=qc_state.id_seq_product,
+        id_qc_type=qc_state.id_qc_type,
+        id_user=qc_state.id_user,
+        id_qc_state_dict=qc_state.id_qc_state_dict,
+        created_by=qc_state.created_by,
+        date_created=qc_state.date_created,
+        date_updated=qc_state.date_updated,
+        is_preliminary=qc_state.is_preliminary,
+    )
 
-        qcdb_session.add(historical_record)
-        qcdb_session.commit()
+    qcdb_session.add(historical_record)
+    qcdb_session.commit()
 
-        # Update the current record
-        try:
-            update_qc_state(qc_status, qc_state, qcdb_session)
-        except Exception as e:
-            raise HTTPException(status_code=400, detail=str(e))
-        qcdb_session.merge(qc_state)
-        qcdb_session.commit()
+    # Update the current record
+    try:
+        update_qc_state(qc_status, qc_state, qcdb_session)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    qcdb_session.merge(qc_state)
+    qcdb_session.commit()
 
     return qc_status_json(qc_state)

--- a/lang_qc/main.py
+++ b/lang_qc/main.py
@@ -23,7 +23,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from lang_qc.endpoints.inbox import router as pacbio_run_router
 from lang_qc.endpoints.pacbio_run import router as inbox_router
-
+from lang_qc.endpoints.qc_state import router as qc_state_router
 
 # Get origins from environment, must be a comma-separated list of origins
 # for example, set CORS_ORIGINS=http://localhost:300,https://example.com:443
@@ -35,6 +35,7 @@ if origins_env is not None:
 app = FastAPI(title="LangQC")
 app.include_router(pacbio_run_router, prefix="/pacbio")
 app.include_router(inbox_router, prefix="/pacbio")
+app.include_router(qc_state_router, prefix="/pacbio")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,

--- a/lang_qc/models/qc_state_models.py
+++ b/lang_qc/models/qc_state_models.py
@@ -16,3 +16,20 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
+
+from pydantic import BaseModel
+
+
+class QcStatusAssignmentPostBody(BaseModel):
+
+    user: str
+    qc_type: str
+    qc_state: str
+    is_preliminary: bool
+
+
+class QcClaimPostBody(BaseModel):
+    """Body for the qc_claim endpoint."""
+
+    user: str
+    qc_type: str

--- a/lang_qc/models/qc_state_models.py
+++ b/lang_qc/models/qc_state_models.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2022 Genome Research Ltd.
+#
+# Author: Adam Blanchet <ab59@sanger.ac.uk>
+#
+# This file is part of npg_langqc.
+#
+# npg_langqc is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.

--- a/lang_qc/util/qc_state_helpers.py
+++ b/lang_qc/util/qc_state_helpers.py
@@ -51,7 +51,17 @@ def create_well_properties_digest(run_name, well_label):
 
 
 def get_seq_product_for_well(run_name: str, well_label: str, qcdb_session: Session):
-    """Get a SeqProduct from a well."""
+    """Get a SeqProduct for a well from the QC database.
+
+    This assumes that there is a 1-1 mapping between SubProduct and SeqProduct.
+    Args:
+        run_name: The run name.
+        well_label: The well label.
+        qcdb_session: A SQLAlchemy Session connected to the QC database.
+
+    Returns:
+        The SeqProduct corresponding to the well.
+    """
 
     return (
         qcdb_session.execute(
@@ -73,7 +83,16 @@ def get_seq_product_for_well(run_name: str, well_label: str, qcdb_session: Sessi
 def get_qc_state_for_well(
     run_name: str, well_label: str, qcdb_session: Session
 ) -> Optional[QcState]:
-    """Get a QcState from a well."""
+    """Get a QcState from a well.
+
+    Args:
+        run_name: The run name.
+        well_label: The well label.
+        qcdb_session: A SQLAlchemy Session connected to the QC database.
+
+    Returns:
+        Either a QcState object if one is found, or None if not.
+    """
 
     return qcdb_session.execute(
         select(QcState)
@@ -92,6 +111,18 @@ def get_qc_state_for_well(
 def construct_seq_product_for_well(
     run_name: str, well_label: str, qcdb_session: Session
 ):
+    """Construct a SeqProduct for a well and push it to the database.
+
+    This assumes a 1-1 mapping between SeqProduct and SubProduct.
+
+    Args:
+        run_name: The run name.
+        well_label: The well label.
+        qcdb_session: A SQLAlchemy Session connected to the QC database.
+
+    Returns:
+        The SeqProduct which has been pushed to the QC database.
+    """
 
     seq_platform = qcdb_session.execute(
         select(SeqPlatform).where(SeqPlatform.name == "PacBio")
@@ -139,6 +170,16 @@ def construct_seq_product_for_well(
 def update_qc_state(
     qc_status_post: QcStatus, qc_state_db: QcState, qcdb_session: Session
 ):
+    """Update the properties of the QcState, without pushing the changes.
+
+    Args:
+        qc_status_post: The object containing the new properties to update.
+        qc_state_db: The object on which to apply the updates.
+        qcdb_session: A SQLAlchemy Session connected to the QC database.
+
+    Returns:
+        None
+    """
 
     # Check that values are in the DB.
     desired_qc_state_dict = qcdb_session.execute(
@@ -174,7 +215,14 @@ def update_qc_state(
 
 
 def qc_status_json(db_qc_state: QcState) -> QcStatus:
+    """Convenience function to convert a DB QcState to a Pydantic QcStatus.
 
+    Args:
+        db_qc_state: the DB QcState object
+
+    Returns:
+        A QcStatus object with the properties from the DB QCState record.
+    """
     return QcStatus(
         user=db_qc_state.user.username,
         date_created=db_qc_state.date_created,

--- a/lang_qc/util/qc_state_helpers.py
+++ b/lang_qc/util/qc_state_helpers.py
@@ -39,7 +39,7 @@ from lang_qc.models.inbox_models import QcStatus
 
 
 def create_id_product(run_name, well_label):
-    return PacBioWell(run_name=run_name, well_label=well_label)
+    return PacBioWell(run_name=run_name, well_label=well_label).hash_product_id()
 
 
 def create_well_properties(run_name, well_label):
@@ -47,7 +47,7 @@ def create_well_properties(run_name, well_label):
 
 
 def create_well_properties_digest(run_name, well_label):
-    return hash(frozenset(create_well_properties(run_name, well_label)))
+    return PacBioWell(run_name=run_name, well_label=well_label).hash_product_id()
 
 
 def get_seq_product_for_well(run_name: str, well_label: str, qcdb_session: Session):

--- a/lang_qc/util/qc_state_helpers.py
+++ b/lang_qc/util/qc_state_helpers.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2022 Genome Research Ltd.
+#
+# Author: Adam Blanchet <ab59@sanger.ac.uk>
+#
+# This file is part of npg_langqc.
+#
+# npg_langqc is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+import json
+from datetime import datetime
+from typing import Optional
+
+from product_id.main import PacBioWell
+from sqlalchemy.orm import Session
+from sqlalchemy import select, and_
+
+from lang_qc.db.qc_schema import (
+    ProductLayout,
+    QcState,
+    QcStateDict,
+    QcType,
+    SeqPlatform,
+    SeqProduct,
+    SubProduct,
+    SubProductAttr,
+    User,
+)
+from lang_qc.models.inbox_models import QcStatus
+
+
+def create_id_product(run_name, well_label):
+    return PacBioWell(run_name=run_name, well_label=well_label)
+
+
+def create_well_properties(run_name, well_label):
+    return json.dumps({"run_name": run_name, "well_label": well_label})
+
+
+def create_well_properties_digest(run_name, well_label):
+    return hash(frozenset(create_well_properties(run_name, well_label)))
+
+
+def get_seq_product_for_well(run_name: str, well_label: str, qcdb_session: Session):
+    """Get a SeqProduct from a well."""
+
+    return (
+        qcdb_session.execute(
+            select(SeqProduct)
+            .join(ProductLayout)
+            .join(SubProduct)
+            .where(
+                and_(
+                    SubProduct.value_attr_one == run_name,
+                    SubProduct.value_attr_two == well_label,
+                )
+            )
+        )
+        .scalars()
+        .one_or_none()
+    )
+
+
+def get_qc_state_for_well(
+    run_name: str, well_label: str, qcdb_session: Session
+) -> Optional[QcState]:
+    """Get a QcState from a well."""
+
+    return qcdb_session.execute(
+        select(QcState)
+        .join(SeqProduct)
+        .join(ProductLayout)
+        .join(SubProduct)
+        .where(
+            and_(
+                SubProduct.value_attr_one == run_name,
+                SubProduct.value_attr_two == well_label,
+            )
+        )
+    ).scalar_one_or_none()
+
+
+def construct_seq_product_for_well(
+    run_name: str, well_label: str, qcdb_session: Session
+):
+
+    seq_platform = qcdb_session.execute(
+        select(SeqPlatform).where(SeqPlatform.name == "PacBio")
+    ).scalar_one_or_none()
+    if seq_platform is None:
+        raise Exception("PacBio SeqPlatform is not in the QC database.")
+
+    run_name_product_attr = qcdb_session.execute(
+        select(SubProductAttr).where(SubProductAttr.attr_name == "run_name")
+    ).scalar_one_or_none()
+    if run_name_product_attr is None:
+        raise Exception("PacBio run name SubProductAttr is not the QC database.")
+
+    well_label_product_attr = qcdb_session.execute(
+        select(SubProductAttr).where(SubProductAttr.attr_name == "well_label")
+    ).scalar_one_or_none()
+    if well_label_product_attr is None:
+        raise Exception("PacBio well label SubProductAttr is not in the QC database.")
+
+    seq_product = SeqProduct(
+        id_product=create_id_product(run_name, well_label),
+        seq_platform=seq_platform,
+        product_layout=[
+            ProductLayout(
+                sub_product=SubProduct(
+                    sub_product_attr=run_name_product_attr,
+                    sub_product_attr_=well_label_product_attr,
+                    value_attr_one=run_name,
+                    value_attr_two=well_label,
+                    properties=create_well_properties(run_name, well_label),
+                    properties_digest=create_well_properties_digest(
+                        run_name, well_label
+                    ),
+                )
+            )
+        ],
+    )
+
+    qcdb_session.add(seq_product)
+    qcdb_session.commit()
+
+    return seq_product
+
+
+def update_qc_state(
+    qc_status_post: QcStatus, qc_state_db: QcState, qcdb_session: Session
+):
+
+    # Check that values are in the DB.
+    desired_qc_state_dict = qcdb_session.execute(
+        select(QcStateDict.id_qc_state_dict).where(
+            QcStateDict.state == qc_status_post.qc_state
+        )
+    ).one_or_none()
+    if desired_qc_state_dict is None:
+        raise Exception(
+            "Desired QC state is not in the QC database. It might not be allowed."
+        )
+
+    user = qcdb_session.execute(
+        select(User).where(User.username == qc_status_post.user)
+    ).scalar_one_or_none()
+    if user is None:
+        raise Exception(
+            "User has not been found in the QC database. Has it been registered?"
+        )
+
+    qc_type = qcdb_session.execute(
+        select(QcType.id_qc_type).where(QcType.qc_type == qc_status_post.qc_type)
+    ).one_or_none()
+    if qc_type is None:
+        raise Exception("QC type is not in the QC database.")
+
+    qc_state_db.user = user
+    qc_state_db.date_updated = datetime.now()
+    qc_state_db.id_qc_state_dict = desired_qc_state_dict[0]
+    qc_state_db.id_qc_type = qc_type[0]
+    qc_state_db.created_by = "LangQC"
+    qc_state_db.is_preliminary = qc_status_post.is_preliminary
+
+
+def qc_status_json(db_qc_state: QcState) -> QcStatus:
+
+    return QcStatus(
+        user=db_qc_state.user.username,
+        date_created=db_qc_state.date_created,
+        date_updated=db_qc_state.date_updated,
+        qc_type=db_qc_state.qc_type.qc_type,
+        qc_type_description=db_qc_state.qc_type.description,
+        qc_state=db_qc_state.qc_state_dict.state,
+        is_preliminary=db_qc_state.is_preliminary,
+        created_by=db_qc_state.created_by,
+    )

--- a/poetry.lock
+++ b/poetry.lock
@@ -28,7 +28,7 @@ tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
 
 [[package]]
 name = "atomicwrites"
-version = "1.4.0"
+version = "1.4.1"
 description = "Atomic file writes."
 category = "dev"
 optional = false
@@ -245,7 +245,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "inflect"
-version = "5.6.0"
+version = "5.6.1"
 description = "Correctly generate plurals, singular nouns, ordinals, indefinite articles; convert numbers to words"
 category = "dev"
 optional = false
@@ -253,7 +253,7 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pygments", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "pygments", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -382,6 +382,24 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "product-id"
+version = "0.1.0"
+description = "Product ID generation for PacBio products."
+category = "main"
+optional = false
+python-versions = "^3.10"
+develop = false
+
+[package.dependencies]
+pydantic-schemaorg = "^1.0.6"
+
+[package.source]
+type = "git"
+url = "https://github.com/absanger/product_id.git"
+reference = "master"
+resolved_reference = "6e1ead80185b56c5bbfc555b8004cceb6600c52d"
+
+[[package]]
 name = "py"
 version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -419,6 +437,17 @@ typing-extensions = ">=3.7.4.3"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
+
+[[package]]
+name = "pydantic-schemaorg"
+version = "1.0.6"
+description = "Pydantic classes for Schema.org"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pydantic = ">=1.8.2,<2.0.0"
 
 [[package]]
 name = "pyflakes"
@@ -524,7 +553,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -594,15 +623,14 @@ sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "sqlalchemy-utils"
-version = "0.38.2"
+version = "0.38.3"
 description = "Various utility functions for SQLAlchemy."
 category = "main"
 optional = false
-python-versions = "~=3.4"
+python-versions = "~=3.6"
 
 [package.dependencies]
-six = "*"
-SQLAlchemy = ">=1.0"
+SQLAlchemy = ">=1.3"
 
 [package.extras]
 arrow = ["arrow (>=0.3.4)"]
@@ -613,8 +641,8 @@ intervals = ["intervals (>=0.7.1)"]
 password = ["passlib (>=1.6,<2.0)"]
 pendulum = ["pendulum (>=2.0.5)"]
 phone = ["phonenumbers (>=5.9.2)"]
-test = ["pytest (>=2.7.1)", "Pygments (>=1.2)", "Jinja2 (>=2.3)", "docutils (>=0.10)", "flexmock (>=0.9.7)", "mock (==2.0.0)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pg8000 (>=1.12.4)", "pytz (>=2014.2)", "python-dateutil (>=2.6)", "pymysql", "flake8 (>=2.4.0)", "isort (>=4.2.2)", "pyodbc", "backports.zoneinfo"]
-test_all = ["Babel (>=1.3)", "Jinja2 (>=2.3)", "Pygments (>=1.2)", "arrow (>=0.3.4)", "colour (>=0.0.4)", "cryptography (>=0.6)", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "furl (>=0.4.1)", "intervals (>=0.7.1)", "isort (>=4.2.2)", "mock (==2.0.0)", "passlib (>=1.6,<2.0)", "pendulum (>=2.0.5)", "pg8000 (>=1.12.4)", "phonenumbers (>=5.9.2)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (>=2.7.1)", "python-dateutil", "python-dateutil (>=2.6)", "pytz (>=2014.2)", "backports.zoneinfo"]
+test = ["pytest (>=2.7.1)", "Pygments (>=1.2)", "Jinja2 (>=2.3)", "docutils (>=0.10)", "flexmock (>=0.9.7)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pg8000 (>=1.12.4)", "pytz (>=2014.2)", "python-dateutil (>=2.6)", "pymysql", "flake8 (>=2.4.0)", "isort (>=4.2.2)", "pyodbc", "backports.zoneinfo"]
+test_all = ["Babel (>=1.3)", "Jinja2 (>=2.3)", "Pygments (>=1.2)", "arrow (>=0.3.4)", "colour (>=0.0.4)", "cryptography (>=0.6)", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "furl (>=0.4.1)", "intervals (>=0.7.1)", "isort (>=4.2.2)", "passlib (>=1.6,<2.0)", "pendulum (>=2.0.5)", "pg8000 (>=1.12.4)", "phonenumbers (>=5.9.2)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (>=2.7.1)", "python-dateutil", "python-dateutil (>=2.6)", "pytz (>=2014.2)", "backports.zoneinfo"]
 timezone = ["python-dateutil"]
 url = ["furl (>=0.4.1)"]
 
@@ -727,7 +755,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "c4695f4313719f6c26f58657352ca1be31d115bb0164d55c8c53f103053426f3"
+content-hash = "5d5f243fb984cf1a1c3c8b8b3944b59c3b40885c3afb6102aff3f8ba2a0ae122"
 
 [metadata.files]
 anyio = [
@@ -738,10 +766,7 @@ asgiref = [
     {file = "asgiref-3.5.2-py3-none-any.whl", hash = "sha256:1d2880b792ae8757289136f1db2b7b99100ce959b2aa57fd69dab783d05afac4"},
     {file = "asgiref-3.5.2.tar.gz", hash = "sha256:4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424"},
 ]
-atomicwrites = [
-    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
-    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
-]
+atomicwrites = []
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
@@ -989,10 +1014,7 @@ idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
-inflect = [
-    {file = "inflect-5.6.0-py3-none-any.whl", hash = "sha256:967d6db69932bac9f1977b8f2dd131a59147f4b56134cfc74a3f44e5adb65223"},
-    {file = "inflect-5.6.0.tar.gz", hash = "sha256:a0612e7bba1028bb7efa121bf8f012aeda9355252d01b257057fa2a8f5859cef"},
-]
+inflect = []
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
@@ -1112,6 +1134,7 @@ pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
+product-id = []
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
@@ -1161,6 +1184,7 @@ pydantic = [
     {file = "pydantic-1.9.1-py3-none-any.whl", hash = "sha256:4988c0f13c42bfa9ddd2fe2f569c9d54646ce84adc5de84228cfe83396f3bd58"},
     {file = "pydantic-1.9.1.tar.gz", hash = "sha256:1ed987c3ff29fff7fd8c3ea3a3ea877ad310aae2ef9889a119e22d3f2db0691a"},
 ]
+pydantic-schemaorg = []
 pyflakes = [
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
@@ -1270,10 +1294,7 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.4.39-cp39-cp39-win_amd64.whl", hash = "sha256:8b773c9974c272aae0fa7e95b576d98d17ee65f69d8644f9b6ffc90ee96b4d19"},
     {file = "SQLAlchemy-1.4.39.tar.gz", hash = "sha256:8194896038753b46b08a0b0ae89a5d80c897fb601dd51e243ed5720f1f155d27"},
 ]
-sqlalchemy-utils = [
-    {file = "SQLAlchemy-Utils-0.38.2.tar.gz", hash = "sha256:9e01d6d3fb52d3926fcd4ea4a13f3540701b751aced0316bff78264402c2ceb4"},
-    {file = "SQLAlchemy_Utils-0.38.2-py3-none-any.whl", hash = "sha256:622235b1598f97300e4d08820ab024f5219c9a6309937a8b908093f487b4ba54"},
-]
+sqlalchemy-utils = []
 starlette = [
     {file = "starlette-0.19.1-py3-none-any.whl", hash = "sha256:5a60c5c2d051f3a8eb546136aa0c9399773a689595e099e0877704d5888279bf"},
     {file = "starlette-0.19.1.tar.gz", hash = "sha256:c6d21096774ecb9639acad41b86b7706e52ba3bf1dc13ea4ed9ad593d47e24c7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ uvicorn = { version = "^0.17", extras = ["standard"] }
 ml-warehouse = { git = "https://github.com/wtsi-npg/ml-warehouse-python.git", tag="1.0.0" }
 SQLAlchemy = { version = "^1.4.35", extras = ["pymysql"] }
 pydantic = "^1.9.0"
+product_id = { git = "https://github.com/absanger/product_id.git", branch="master"}
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"

--- a/tests/fixtures/inbox_data.py
+++ b/tests/fixtures/inbox_data.py
@@ -83,7 +83,9 @@ def inbox_data(mlwhdb_test_session):
 def test_data_factory(mlwhdb_test_session, qcdb_test_session):
     def setup_data(desired_wells):
         # Setup dicts and "filler" data
-        library_qc_type = QcType(qc_type="Library", description="Library QC")
+        library_qc_type = QcType(
+            qc_type="library", description="Sample/library evaluation"
+        )
 
         run_name_attr = SubProductAttr(
             attr_name="run_name", description="PacBio run name."

--- a/tests/test_assign_qc_state.py
+++ b/tests/test_assign_qc_state.py
@@ -114,3 +114,27 @@ def test_error_on_invalid_values(
 
     assert response.status_code == 400
     assert response.json()["detail"] == expected_message
+
+
+def test_error_on_unclaimed_well(test_client: TestClient, test_data_factory):
+    """Test error on assigning a new state to an unclaimed well."""
+
+    test_data = {"MARATHON": {"A1": None, "B1": None}}
+    test_data_factory(test_data)
+
+    post_data = {
+        "user": "zx80",
+        "qc_type": "library",
+        "qc_state": "Passed",
+        "is_preliminary": True,
+    }
+
+    response = test_client.post(
+        "/pacbio/run/MARATHON/well/A1/qc_assign", json.dumps(post_data)
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "Cannot assign a state to a well which has not yet been claimed."
+    )

--- a/tests/test_assign_qc_state.py
+++ b/tests/test_assign_qc_state.py
@@ -1,0 +1,116 @@
+import json
+
+from tests.fixtures.inbox_data import test_data_factory
+
+from fastapi.testclient import TestClient
+import pytest
+
+
+def test_change_non_existent_well(test_client: TestClient, test_data_factory):
+    """Expect an error if we try to assign a state to a well which doesn't exist."""
+
+    test_data = {
+        "DONT-USE-THIS-RUN": {"A1": None, "B1": None},
+        "NOR-THIS-ONE": {"A1": "Passed", "B1": "Failed"},
+    }
+    test_data_factory(test_data)
+
+    post_data = """
+        {
+          "user": "user2",
+          "date_created": "2022-07-11T13:04:34",
+          "date_updated": "2022-07-11T13:04:34",
+          "qc_type": "library",
+          "qc_type_description": "Sample/library evaluation",
+          "qc_state": "Passed",
+          "is_preliminary": true,
+          "created_by": "LangQC"
+        }
+    """
+
+    response = test_client.post("/pacbio/run/NONEXISTENT/well/A0/qc_assign", post_data)
+
+    assert response.status_code == 400
+
+
+def test_change_from_passed_to_fail(test_client: TestClient, test_data_factory):
+    """Successfully change a state from passed to faield"""
+
+    test_data = {
+        "MARATHON": {"A1": "Passed", "B1": None},
+        "SEMI-MARATHON": {"D1": "Claimed"},
+    }
+    test_data_factory(test_data)
+
+    post_data = """
+        {
+          "user": "zx80",
+          "date_created": "2022-07-11T13:04:34",
+          "date_updated": "2022-07-11T13:04:34",
+          "qc_type": "library",
+          "qc_type_description": "Sample/library evaluation",
+          "qc_state": "Failed",
+          "is_preliminary": false,
+          "created_by": "LangQC"
+        }
+    """
+
+    response = test_client.post("/pacbio/run/MARATHON/well/A1/qc_assign", post_data)
+
+    assert response.status_code == 200
+
+    content = response.json()
+
+    expected = {
+        "user": "zx80",
+        "qc_type": "library",
+        "qc_type_description": "Sample/library evaluation",
+        "qc_state": "Failed",
+        "is_preliminary": False,
+        "created_by": "LangQC",
+    }
+
+    for key, value in expected.items():
+        assert content[key] == value
+
+
+@pytest.mark.parametrize(
+    "invalid_argument,expected_message",
+    [
+        ("qc_type", "QC type is not in the QC database."),
+        ("user", "User has not been found in the QC database. Has it been registered?"),
+        (
+            "qc_state",
+            "Desired QC state is not in the QC database. It might not be allowed.",
+        ),
+    ],
+)
+def test_error_on_invalid_values(
+    test_client: TestClient, test_data_factory, invalid_argument, expected_message
+):
+    """Test errors returned when invalid arguments are provided."""
+
+    test_data = {
+        "MARATHON": {"A1": "Passed", "B1": None},
+        "SEMI-MARATHON": {"D1": "Claimed"},
+    }
+    test_data_factory(test_data)
+
+    post_data = {
+        "user": "zx80",
+        "date_created": "2022-07-11T13:04:34",
+        "date_updated": "2022-07-11T13:04:34",
+        "qc_type": "library",
+        "qc_type_description": "Sample/library evaluation",
+        "qc_state": "Failed",
+        "is_preliminary": False,
+        "created_by": "LangQC",
+    }
+
+    post_data[invalid_argument] = "thisdefinitelyisnotavalidvalue"
+    response = test_client.post(
+        "/pacbio/run/MARATHON/well/A1/qc_assign", json.dumps(post_data)
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == expected_message

--- a/tests/test_assign_qc_state.py
+++ b/tests/test_assign_qc_state.py
@@ -17,14 +17,10 @@ def test_change_non_existent_well(test_client: TestClient, test_data_factory):
 
     post_data = """
         {
-          "user": "user2",
-          "date_created": "2022-07-11T13:04:34",
-          "date_updated": "2022-07-11T13:04:34",
+          "user": "zx80",
           "qc_type": "library",
-          "qc_type_description": "Sample/library evaluation",
           "qc_state": "Passed",
-          "is_preliminary": true,
-          "created_by": "LangQC"
+          "is_preliminary": true
         }
     """
 
@@ -45,13 +41,9 @@ def test_change_from_passed_to_fail(test_client: TestClient, test_data_factory):
     post_data = """
         {
           "user": "zx80",
-          "date_created": "2022-07-11T13:04:34",
-          "date_updated": "2022-07-11T13:04:34",
           "qc_type": "library",
-          "qc_type_description": "Sample/library evaluation",
           "qc_state": "Failed",
-          "is_preliminary": false,
-          "created_by": "LangQC"
+          "is_preliminary": false
         }
     """
 
@@ -98,13 +90,9 @@ def test_error_on_invalid_values(
 
     post_data = {
         "user": "zx80",
-        "date_created": "2022-07-11T13:04:34",
-        "date_updated": "2022-07-11T13:04:34",
         "qc_type": "library",
-        "qc_type_description": "Sample/library evaluation",
         "qc_state": "Failed",
         "is_preliminary": False,
-        "created_by": "LangQC",
     }
 
     post_data[invalid_argument] = "thisdefinitelyisnotavalidvalue"

--- a/tests/test_claim_well.py
+++ b/tests/test_claim_well.py
@@ -79,3 +79,25 @@ def test_claim_well_unknown_user(test_client: TestClient, test_data_factory):
         response.json()["detail"]
         == "User has not been found in the QC database. Has it been registered?"
     )
+
+
+def test_error_on_already_claimed(test_client: TestClient, test_data_factory):
+    """Expect an error when claiming a well which has already been claimed"""
+
+    test_data = {
+        "MARATHON": {"A1": "Failed", "B1": "On hold"},
+        "SEMI-MARATHON": {"D1": "Claimed", "A1": "Passed"},
+    }
+    test_data_factory(test_data)
+
+    post_data = {"user": "zx80", "qc_type": "library"}
+
+    for run_name in test_data:
+        for well_label in test_data[run_name]:
+
+            response = test_client.post(
+                f"/pacbio/run/{run_name}/well/{well_label}/qc_claim",
+                json.dumps(post_data),
+            )
+            assert response.status_code == 400
+            assert response.json()["detail"] == "The well has already been claimed."

--- a/tests/test_claim_well.py
+++ b/tests/test_claim_well.py
@@ -1,0 +1,81 @@
+import json
+
+from tests.fixtures.inbox_data import test_data_factory
+
+from fastapi.testclient import TestClient
+
+
+def test_claim_nonexistent_well(test_client: TestClient, test_data_factory):
+    """Expect an error if we try to claim a well which doesn't exist."""
+
+    test_data = {
+        "DONT-USE-THIS-RUN": {"A1": None, "B1": None},
+        "NOR-THIS-ONE": {"A1": "Passed", "B1": "Failed"},
+    }
+    test_data_factory(test_data)
+
+    post_data = {
+        "user": "zx80",
+        "qc_type": "library",
+    }
+
+    response = test_client.post(
+        "/pacbio/run/NONEXISTENT/well/A0/qc_claim", json.dumps(post_data)
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Well is not in the MLWH database."
+
+
+def test_claim_well_simple(test_client: TestClient, test_data_factory):
+    """Successfully claim an unclaimed well."""
+
+    test_data = {
+        "MARATHON": {"A1": None, "B1": None},
+        "SEMI-MARATHON": {"D1": "Claimed", "A1": "Passed"},
+    }
+    test_data_factory(test_data)
+
+    post_data = {"user": "zx80", "qc_type": "library"}
+
+    response = test_client.post(
+        "/pacbio/run/MARATHON/well/B1/qc_claim", json.dumps(post_data)
+    )
+
+    assert response.status_code == 200
+
+    actual_content = response.json()
+
+    expected = {
+        "user": "zx80",
+        "qc_type": "library",
+        "qc_type_description": "Sample/library evaluation",
+        "qc_state": "Claimed",
+        "is_preliminary": True,
+        "created_by": "LangQC",
+    }
+
+    for key, expected_value in expected.items():
+        assert actual_content[key] == expected_value
+
+
+def test_claim_well_unknown_user(test_client: TestClient, test_data_factory):
+    """Expect an error when claiming a well as an unknown user."""
+
+    test_data = {
+        "MARATHON": {"A1": None, "B1": None},
+        "SEMI-MARATHON": {"D1": "Claimed", "A1": "Passed"},
+    }
+    test_data_factory(test_data)
+
+    post_data = {"user": "Dave", "qc_type": "library"}
+
+    response = test_client.post(
+        "/pacbio/run/MARATHON/well/B1/qc_claim", json.dumps(post_data)
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "User has not been found in the QC database. Has it been registered?"
+    )


### PR DESCRIPTION
Add `/pacbio/run/{run_name}/well/{well_label}/qc_assign`.

Doesn't yet prevent you from changing the assigned user. That is to be added, changing assigned/claiming user will be left to `...../qc_claim` and `......./qc_steal` endpoints.

Based off #22, so you can see the diff to that here: https://github.com/absanger/npg_langqc/compare/feature/inbox-filtering...absanger:npg_langqc:feature/qc-status?expand=1