### PR TITLE
Gracefully stop the proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     command: uvicorn lang_qc.main:app --host 0.0.0.0 --port 8181
 
   proxy_server:
+    depends_on:
+      - lang_qc
+      - longue_vue
     build: ./docker/proxy/
     ports:
       - "${HTTPS_PORT}:443"
@@ -26,6 +29,8 @@ services:
 
 
   longue_vue:
+    depends_on:
+      - lang_qc
     build: 
       context: ./frontend
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,4 +31,3 @@ services:
       args:
         API_SERVER_HOST: $SERVER_HOST
         BASE_PATH: /ui/
-    

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -21,6 +21,14 @@ RUN a2enmod proxy\
   # Redirect logs to stdout/stderr for easier docker logging.
   && ln -sf /dev/stdout /var/log/apache2/access.log \
   && ln -sf /dev/stdout /var/log/apache2/other_vhosts_access.log \
-  && ln -sf /dev/stderr /var/log/apache2/error.log
+  && ln -sf /dev/stderr /var/log/apache2/error.log \
+  # Apache2 seems to need this folder when run directly
+  # apache2ctl usually checks if it exists and makes it / cleans it up
+  && mkdir /var/run/apache2
 
-CMD ["apachectl", "-D", "FOREGROUND"]
+# Allow apache2 to shutdown gracefully
+STOPSIGNAL SIGWINCH
+
+COPY start.sh /start.sh
+
+CMD ["/start.sh"]

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -24,7 +24,7 @@ RUN a2enmod proxy\
   && ln -sf /dev/stderr /var/log/apache2/error.log \
   # Apache2 seems to need this folder when run directly
   # apache2ctl usually checks if it exists and makes it / cleans it up
-  && mkdir /var/run/apache2
+  && mkdir -p /var/run/apache2
 
 # Allow apache2 to shutdown gracefully
 STOPSIGNAL SIGWINCH

--- a/docker/proxy/start.sh
+++ b/docker/proxy/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+. /etc/apache2/envvars
+
+exec apache2 -D FOREGROUND


### PR DESCRIPTION
Change how `apache2` is run in the proxy service container, and get it to receive a `SIGWINCH` for a graceful stop.
Add dependencies between the services for proper ordering of startup and shutdown.