### PR TITLE
Specify production image in github workflow.

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           # Set BRANCH to latest if BRANCH is master
           [ $BRANCH = "master" ] && BRANCH=latest
-          docker build --label $REPOLABEL -t ghcr.io/${{ github.repository_owner }}/npg_langqc:${BRANCH} .
+          docker build --target production --label $REPOLABEL -t ghcr.io/${{ github.repository_owner }}/npg_langqc:${BRANCH} .
           docker image push ghcr.io/${{ github.repository_owner}}/npg_langqc:${BRANCH}
         env:
           REPOLABEL: "org.opencontainers.image.source=${{ github.repository_url }}"


### PR DESCRIPTION
In #29, the main `Dockerfile` got two separate targets. So since then, the last target in the `Dockerfile` is the one which was being published, in our case `development`.

This PR sets the target to `production` which is probably what we actually want to publish.