### PR TITLE
Decrufting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    
+
     runs-on: ubuntu-latest
 
     steps:
@@ -17,13 +17,13 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install poetry
-      
+
       - uses: actions/setup-python@v3
         with:
           python-version: '3.10'
           architecture: 'x64'
           # cache: 'poetry'
-      
+
       - name: Run poetry install
         run: |
           poetry env use '3.10'
@@ -40,3 +40,15 @@ jobs:
       - name: Run isort
         run: |
           poetry run isort --check --diff --color .
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Set up JS requirements
+        run: npm install
+        working-directory: ./frontend
+
+      - name: Run ESLint
+        run: npm run lint
+        working-directory: ./frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - lang_qc
       - longue_vue
-    build: 
+    build:
       context: ./docker/proxy/
       target: production
     ports:
@@ -33,9 +33,8 @@ services:
   longue_vue:
     depends_on:
       - lang_qc
-    build: 
+    build:
       context: ./frontend
       target: production
       args:
-        API_SERVER_HOST: $SERVER_HOST
         BASE_PATH: /ui/

--- a/docker/proxy/000-default.conf
+++ b/docker/proxy/000-default.conf
@@ -50,7 +50,7 @@
     OIDCCryptoPassphrase ${OIDCCryptoPassphrase}
     OIDCScope "openid email"
     OIDCInfoHook userinfo
-    OIDCSessionInactivityTimeout 300
+    OIDCSessionInactivityTimeout 1200
 
     # Redirect from root to the root of the web app.
     RedirectMatch 301 ^/$ /ui/

--- a/docker/proxy/000-default.conf.dev
+++ b/docker/proxy/000-default.conf.dev
@@ -48,6 +48,7 @@
     OIDCCryptoPassphrase ${OIDCCryptoPassphrase}
     OIDCScope "openid email"
     OIDCInfoHook userinfo
+    OIDCSessionInactivityTimeout 1200
 
     # Redirect from root to the root of the web app.
     RedirectMatch 301 ^/$ /ui/

--- a/docker/proxy/000-default.conf.dev
+++ b/docker/proxy/000-default.conf.dev
@@ -8,6 +8,8 @@
     # Example:
 
     # Proxy to lang_qc API server
+    ProxyPass  /openapi/ http://lang_qc:8181/openapi/
+    ProxyPassReverse /openapi/ http://lang_qc:8181/openapi/
     ProxyPass  /api/ http://lang_qc:8181/
     ProxyPassReverse /api/ http://lang_qc:8181/
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as base-stage
+FROM node:18 as base-stage
 
 COPY  package.json /code/longue_vue/
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,12 +9,10 @@ RUN npm install
 FROM base-stage as production-build-stage
 
 ARG BASE_PATH=/ui/
-ARG API_SERVER_HOST="https://localhost/"
 
 COPY . /code/longue_vue/
 
-RUN  sed -i "s,https://dev-langqc.dnapipelines.sanger.ac.uk,${API_SERVER_HOST}/,g" ./src/views/RunView.vue \
-  && npm run build -- --base=${BASE_PATH}
+RUN npm run build -- --base=${BASE_PATH}
 
 FROM httpd:alpine as production
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 as base-stage
+FROM node:18-alpine as base-stage
 
 COPY  package.json /code/longue_vue/
 


### PR DESCRIPTION
- Remove the last remains of an old hack to make the front end direct API requests to the back end.
- Add ESLint to the github workflow
- Reduce the aggressiveness of the default OICD timeout to reduce hair-tearing.
- Update dev apache conf to match production
- Reduce frontend docker image size by half by switching over to Alpine