### PR TITLE
Reduced run time for tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ def create_mlwhdb_test_sessionfactory(config):
     return TestingSessionLocal
 
 
-@pytest.fixture
+@pytest.fixture(scope="module", name="mlwhdb_test_session")
 def mlwhdb_test_session(mlwhdb_test_sessionfactory):
     with mlwhdb_test_sessionfactory() as session:
         yield session

--- a/tests/fixtures/inbox_data.py
+++ b/tests/fixtures/inbox_data.py
@@ -10,6 +10,7 @@ from ml_warehouse.schema import (
     Study,
 )
 from npg_id_generation.pac_bio import PacBioEntity
+from sqlalchemy import delete, text
 
 from lang_qc.db.qc_schema import (
     ProductLayout,
@@ -94,6 +95,18 @@ def inbox_data(mlwhdb_test_session):
             )
         )
 
+    mlwhdb_test_session.commit()
+
+    yield True
+
+    print("\nTEARDOWN inbox_data")
+    mlwhdb_test_session.execute(text("SET foreign_key_checks=0;"))
+    mlwhdb_test_session.execute(delete(PacBioProductMetrics))
+    mlwhdb_test_session.execute(delete(PacBioRun))
+    mlwhdb_test_session.execute(delete(Study))
+    mlwhdb_test_session.execute(delete(Sample))
+    mlwhdb_test_session.execute(delete(PacBioRunWellMetrics))
+    mlwhdb_test_session.execute(text("SET foreign_key_checks=1;"))
     mlwhdb_test_session.commit()
 
 
@@ -202,7 +215,31 @@ def test_data_factory(mlwhdb_test_session, qcdb_test_session):
 
         return desired_wells
 
-    return setup_data
+    yield setup_data
+
+    print("\nTEARDOWN test_data_factory")
+
+    mlwhdb_test_session.execute(text("SET foreign_key_checks=0;"))
+    mlwhdb_test_session.execute(delete(PacBioProductMetrics))
+    mlwhdb_test_session.execute(delete(PacBioRun))
+    mlwhdb_test_session.execute(delete(Study))
+    mlwhdb_test_session.execute(delete(Sample))
+    mlwhdb_test_session.execute(delete(PacBioRunWellMetrics))
+    mlwhdb_test_session.execute(text("SET foreign_key_checks=1;"))
+    mlwhdb_test_session.commit()
+
+    qcdb_test_session.execute(text("SET foreign_key_checks=0;"))
+    qcdb_test_session.execute(delete(QcState))
+    qcdb_test_session.execute(delete(ProductLayout))
+    qcdb_test_session.execute(delete(SeqProduct))
+    qcdb_test_session.execute(delete(SubProduct))
+    qcdb_test_session.execute(delete(QcType))
+    qcdb_test_session.execute(delete(SubProductAttr))
+    qcdb_test_session.execute(delete(SeqPlatform))
+    qcdb_test_session.execute(delete(User))
+    qcdb_test_session.execute(delete(QcStateDict))
+    qcdb_test_session.execute(text("SET foreign_key_checks=1;"))
+    qcdb_test_session.commit()
 
 
 @pytest.fixture()

--- a/tests/fixtures/qc_db_basic_data.py
+++ b/tests/fixtures/qc_db_basic_data.py
@@ -46,13 +46,11 @@ USERS = [
 ]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def load_dicts_and_users(qcdb_test_session):
 
     _dicts_and_users(qcdb_test_session)
     qcdb_test_session.commit()
-
-    return qcdb_test_session
 
 
 def _dicts_and_users(session):

--- a/tests/test_qc_state_maintenance.py
+++ b/tests/test_qc_state_maintenance.py
@@ -14,9 +14,10 @@ from lang_qc.db.qc_schema import QcState, QcStateHist, User
 from tests.fixtures.qc_db_basic_data import load_dicts_and_users
 
 
-def test_dict_helper(load_dicts_and_users):
+def test_dict_helper(qcdb_test_session, load_dicts_and_users):
 
-    session = load_dicts_and_users
+    session = qcdb_test_session
+    load_dicts_and_users
 
     helper = QcDictDB(session=session)
 
@@ -47,9 +48,10 @@ def test_dict_helper(load_dicts_and_users):
     assert list(helper.qc_states.keys()) == expected_sorted_states
 
 
-def test_well_state_helper(load_dicts_and_users):
+def test_well_state_helper(qcdb_test_session, load_dicts_and_users):
 
-    session = load_dicts_and_users
+    session = qcdb_test_session
+    load_dicts_and_users
     users = session.execute(select(User)).scalars().all()
     user1 = users[0].username
     user2 = users[1].username


### PR DESCRIPTION
Set the scope of fixtures to 'module' or 'package' where possible. The fixtures that create databases are now run once per module (test file). Sourcing of credentials for databases is done once per the pytest run ('package' scope).

Added the teardown section (after the 'yield' statement) to fixtures with the 'function' scope (the default scope of the pytest fixtures). The teardown section deletes all data that the fixture loaded to the databases.

Dropped altering the settings of the mlwh database at the stage of creating the schema. Instead, foreign keys constraints are now dropped at the teardown section and reinstated once data deletion is done.