### PR TITLE
De-restrict QC state assignment via API to allow any registered user …

### DIFF
--- a/lang_qc/endpoints/pacbio_well.py
+++ b/lang_qc/endpoints/pacbio_well.py
@@ -195,12 +195,6 @@ def assign_qc_state(
             detail="QC state of an unclaimed well cannot be updated",
         )
 
-    if qc_state.user.username != user.username:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Unauthorised, QC is performed by another user",
-        )
-
     qc_state = None
     message = "Error assigning status: "
     try:

--- a/tests/endpoints/test_assign_qc_state.py
+++ b/tests/endpoints/test_assign_qc_state.py
@@ -199,15 +199,15 @@ def test_error_on_unclaimed_well(test_client: TestClient, test_data_factory):
     )
 
 
-def test_error_on_preclaimed_well(test_client: TestClient, test_data_factory):
-    """Test error on assigning a new state to a well claimed by another user."""
+def test_preclaimed_well(test_client: TestClient, test_data_factory):
+    """Other valid users should be able to set new QC states."""
 
     test_data = {"MARATHON": {"A1": "Passed", "B1": None}}
     test_data_factory(test_data)
 
     post_data = {
         "qc_type": "library",
-        "qc_state": "Passed",
+        "qc_state": "Failed",
         "is_preliminary": True,
     }
 
@@ -217,5 +217,5 @@ def test_error_on_preclaimed_well(test_client: TestClient, test_data_factory):
         headers={"OIDC_CLAIM_EMAIL": "cd32@example.com"},
     )
 
-    assert response.status_code == 403
-    assert response.json()["detail"] == "Unauthorised, QC is performed by another user"
+    assert response.status_code == 200
+    assert response.json()["qc_state"] == "Failed"


### PR DESCRIPTION
…to override the previous setting