### PR TITLE
Preparation for a new endpoint for retrieval wells in runs

### DIFF
--- a/lang_qc/db/helper/wells.py
+++ b/lang_qc/db/helper/wells.py
@@ -31,8 +31,8 @@ from sqlalchemy.orm import Session
 from lang_qc.db.helper.well import WellQc
 from lang_qc.db.qc_schema import QcState, QcStateDict, QcType
 from lang_qc.models.pacbio.well import PacBioPagedWells, PacBioWell
-from lang_qc.models.pager import PagedStatusResponse
-from lang_qc.models.qc_flow_status import QcFlowStatusEnum
+from lang_qc.models.pager import PagedResponse
+from lang_qc.models.qc_flow_status import QcFlowStatusEnum, QcFlowStatusMixin
 from lang_qc.models.qc_state import QcState as QcStateModel
 
 """
@@ -133,7 +133,7 @@ class WellWh(BaseModel):
         return self.session.execute(query).scalars().all()
 
 
-class PacBioPagedWellsFactory(WellWh, PagedStatusResponse):
+class PacBioPagedWellsFactory(WellWh, PagedResponse, QcFlowStatusMixin):
     """
     Factory class to create `PacBioPagedWells` objects that correspond to
     the criteria given by the attributes of the object, i.e. `page_size`

--- a/lang_qc/db/helper/wells.py
+++ b/lang_qc/db/helper/wells.py
@@ -95,9 +95,9 @@ class WellWh(BaseModel):
         # TODO: to be implemented
         return []
 
-    def recent_completed_wells(self) -> List[PacBioRunWellMetrics]:
+    def get_recently_completed_wells(self) -> List[PacBioRunWellMetrics]:
         """
-        Get recent completed wells from the mlwh database.
+        Get recently completed wells from the mlwh database.
         The implementation of the inbox query might change when the QC outcomes
         become available in mlwh.
         """
@@ -263,7 +263,7 @@ class PacBioPagedWellsFactory(PacBioPagedWellsFactoryLite, QcFlowStatusMixin):
 
         wells = []
         if self.qc_flow_status == QcFlowStatusEnum.INBOX:
-            recent_wells = self.recent_completed_wells()
+            recent_wells = self.get_recently_completed_wells()
             wells = self._recent_inbox_wells(recent_wells)
         elif self.qc_flow_status in [
             QcFlowStatusEnum.ABORTED,

--- a/lang_qc/db/helper/wells.py
+++ b/lang_qc/db/helper/wells.py
@@ -87,13 +87,13 @@ class WellWh(BaseModel):
 
         return bool(self.get_well(run_name, well_label))
 
-    def get_wells_for_runs(self, run_names: List[str]) -> List[PacBioRunWellMetrics]:
+    def get_wells_in_runs(self, run_names: List[str]) -> List[PacBioRunWellMetrics]:
         """
         Returns a potentially empty list of well records for runs with names
         given by the run_names argument.
         """
-
-        pass
+        # TODO: to be implemented
+        return []
 
     def recent_completed_wells(self) -> List[PacBioRunWellMetrics]:
         """
@@ -204,7 +204,15 @@ class PacBioPagedWellsFactoryLite(WellWh, PagedResponse):
         by the run name and well label.
         """
 
-        pass
+        wells = self.get_wells_in_runs(run_names)
+        total_number_of_wells = len(wells)
+        wells = self.slice_data(wells)
+        return PacBioPagedWellsLite(
+            page_number=self.page_number,
+            page_size=self.page_size,
+            total_number_of_items=total_number_of_wells,
+            wells=self.generate_well_models(wells),
+        )
 
 
 class PacBioPagedWellsFactory(PacBioPagedWellsFactoryLite, QcFlowStatusMixin):

--- a/lang_qc/endpoints/pacbio_well.py
+++ b/lang_qc/endpoints/pacbio_well.py
@@ -47,11 +47,12 @@ router = APIRouter(
     "/wells",
     summary="Get a list of runs with wells filtered by status",
     description="""
-         Taking an optional 'qc_status' as a query parameter, returns a list of
-         runs with wells filtered by status. The default qc status is 'inbox'.
-         Possible values for this parameter are defined in QcFlowStatusEnum. For the
-         inbox view an optional 'weeks' query parameter can be used, it defaults
-         to one week and defines the number of weeks to look back.
+    Taking an optional 'qc_status' as a query parameter, returns a list of
+    wells filtered by QC status. The default QC status is 'inbox'. Possible
+    values for this parameter are defined in QcFlowStatusEnum.
+    
+    The list is paged according to non-optional parameters `page_size` and
+    `page_number`.   
     """,
     responses={
         status.HTTP_422_UNPROCESSABLE_ENTITY: {

--- a/lang_qc/models/pacbio/well.py
+++ b/lang_qc/models/pacbio/well.py
@@ -29,7 +29,8 @@ from sqlalchemy.orm import Session
 from lang_qc.db.helper.well import WellQc
 from lang_qc.models.pacbio.experiment import PacBioExperiment
 from lang_qc.models.pacbio.qc_data import QCDataWell
-from lang_qc.models.pager import PagedStatusResponse
+from lang_qc.models.pager import PagedResponse
+from lang_qc.models.qc_flow_status import QcFlowStatusMixin
 from lang_qc.models.qc_state import QcState
 
 
@@ -81,7 +82,7 @@ class PacBioWell(BaseModel, extra=Extra.forbid):
         self.well_status = db_well.well_status
 
 
-class PacBioPagedWells(PagedStatusResponse, extra=Extra.forbid):
+class PacBioPagedWellsLite(PagedResponse, extra=Extra.forbid):
     """
     A response model for paged data about PacBio wells.
     """
@@ -90,11 +91,21 @@ class PacBioPagedWells(PagedStatusResponse, extra=Extra.forbid):
         default=[],
         title="A list of PacBioWell objects",
         description="""
-        A list of `PacBioWell` objects that corresponds to the QC flow status
-        given by the `qc_flow_status` attribute and the page number and size
-        specified by the `page_size` and `page_number` attributes.
+        A list of paged `PacBioWell` objects that corresponds to the page number
+        and size specified by the `page_size` and `page_number` attributes.
         """,
     )
+
+
+class PacBioPagedWells(PacBioPagedWellsLite, QcFlowStatusMixin, extra=Extra.forbid):
+    """
+    A response model for paged data about PacBio wells. All `PacBioWell` objects
+    of the `wells` attribute correspond to the QC flow status given by the
+    `qc_flow_status` attribute and the page number and size specified by the
+    `page_size` and `page_number` attributes.
+    """
+
+    pass
 
 
 class PacBioWellFull(PacBioWell):

--- a/lang_qc/models/pager.py
+++ b/lang_qc/models/pager.py
@@ -65,14 +65,3 @@ class PagedResponse(BaseModel):
         from_number = self.page_size * (self.page_number - 1)
         to_number = from_number + self.page_size
         return data[from_number:to_number]
-
-
-class PagedStatusResponse(PagedResponse):
-    """
-    A response model for paged data that relates to a particular QC flow
-    status, described by the `qc_flow_status` attribute.
-    """
-
-    qc_flow_status: QcFlowStatusEnum = Field(
-        title="QC flow status", description="QC flow status used for the selection."
-    )

--- a/lang_qc/models/qc_flow_status.py
+++ b/lang_qc/models/qc_flow_status.py
@@ -68,3 +68,11 @@ class QcFlowStatusEnum(str, Enum):
             statuses.append(QcFlowStatus(label=label, param=member))
 
         return statuses
+
+
+class QcFlowStatusMixin(BaseModel):
+    """
+    A mixin with a single attribute - `qc_flow_status`.
+    """
+
+    qc_flow_status: QcFlowStatusEnum = Field(title="QC flow status")

--- a/tests/test_wells4runs_retrieval.py
+++ b/tests/test_wells4runs_retrieval.py
@@ -1,0 +1,52 @@
+import pytest
+
+from lang_qc.db.helper.wells import PacBioPagedWellsFactoryLite
+from lang_qc.models.pacbio.well import PacBioPagedWellsLite
+from tests.fixtures.well_data import load_data4well_retrieval, load_dicts_and_users
+
+
+def test_empty_list_input(
+    qcdb_test_session, mlwhdb_test_session, load_data4well_retrieval
+):
+
+    factory = PacBioPagedWellsFactoryLite(
+        qcdb_session=qcdb_test_session,
+        mlwh_session=mlwhdb_test_session,
+        page_size=10,
+        page_number=1,
+    )
+
+    paged_wells_obj = factory.create_for_runs([])
+    assert isinstance(paged_wells_obj, PacBioPagedWellsLite)
+    assert paged_wells_obj.page_size == 10
+    assert paged_wells_obj.page_number == 1
+    assert paged_wells_obj.wells == []
+
+
+def test_unknown_run_input(
+    qcdb_test_session, mlwhdb_test_session, load_data4well_retrieval
+):
+
+    factory = PacBioPagedWellsFactoryLite(
+        qcdb_session=qcdb_test_session,
+        mlwh_session=mlwhdb_test_session,
+        page_size=5,
+        page_number=1,
+    )
+    paged_wells_obj = factory.create_for_runs(["some run"])
+    assert isinstance(paged_wells_obj, PacBioPagedWellsLite)
+    assert paged_wells_obj.page_size == 5
+    assert paged_wells_obj.page_number == 1
+    assert paged_wells_obj.wells == []
+
+    factory = PacBioPagedWellsFactoryLite(
+        qcdb_session=qcdb_test_session,
+        mlwh_session=mlwhdb_test_session,
+        page_size=5,
+        page_number=3,
+    )
+    paged_wells_obj = factory.create_for_runs(["some run", "other run"])
+    assert isinstance(paged_wells_obj, PacBioPagedWellsLite)
+    assert paged_wells_obj.page_size == 5
+    assert paged_wells_obj.page_number == 3
+    assert paged_wells_obj.wells == []

--- a/tests/test_wh_pac_bio_data_retrieval.py
+++ b/tests/test_wh_pac_bio_data_retrieval.py
@@ -50,7 +50,7 @@ def test_completed_wells_retrieval(mlwhdb_test_session, load_data4well_retrieval
     mlwhdb_test_session.commit()
 
     retriever = WellWh(session=mlwhdb_test_session)
-    wells = retriever.recent_completed_wells()
+    wells = retriever.get_recently_completed_wells()
     wells_ids = [[well.pac_bio_run_name, well.well_label] for well in wells]
     assert len(wells_ids) == len(expected)
     assert wells_ids == expected

--- a/tests/test_wh_pac_bio_data_retrieval.py
+++ b/tests/test_wh_pac_bio_data_retrieval.py
@@ -72,3 +72,10 @@ def test_well_metrics_retrieval(mlwhdb_test_session, load_data4well_retrieval):
     assert well.polymerase_num_reads == 3339714
     assert well.hifi_num_reads == 2226107
     assert wm.well_exists(run_name="TRACTION_RUN_12", well_label="A1") is True
+
+
+def test_wells_in_runs_retrieval(mlwhdb_test_session, load_data4well_retrieval):
+
+    wm = WellWh(session=mlwhdb_test_session)
+    assert wm.get_wells_in_runs([]) == []
+    assert wm.get_wells_in_runs(["some name"]) == []


### PR DESCRIPTION
The code is refactored to alow for retrieval of wells that are not associated with any particular QC flow state.

Th eadded functionality for retrieval wells for a list of runs in not fully implemented yet. It is added to demonstrate the logic behind the reorganisation of the code.