### PR TITLE
Removed qc_flow_status key from JSON response.

### DIFF
--- a/lang_qc/db/helper/wells.py
+++ b/lang_qc/db/helper/wells.py
@@ -170,7 +170,9 @@ class PacBioPagedWellsFactory(WellWh, PagedResponse):
         extra = Extra.forbid
         allow_mutation = True
 
-    def create(self, qc_flow_status: QcFlowStatusEnum) -> PacBioPagedWells:
+    def create_for_qc_status(
+        self, qc_flow_status: QcFlowStatusEnum
+    ) -> PacBioPagedWells:
         """
         Returns `PacBioPagedWells` object that corresponds to the criteria
         specified by the `page_size`, `page_number` object's attributes and

--- a/lang_qc/db/helper/wells.py
+++ b/lang_qc/db/helper/wells.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import Session
 from lang_qc.db.helper.well import WellQc
 from lang_qc.db.qc_schema import QcState, QcStateDict, QcType
 from lang_qc.models.pacbio.well import PacBioPagedWells, PacBioWell
-from lang_qc.models.pager import PagedStatusResponse
+from lang_qc.models.pager import PagedResponse
 from lang_qc.models.qc_flow_status import QcFlowStatusEnum
 from lang_qc.models.qc_state import QcState as QcStateModel
 
@@ -133,11 +133,12 @@ class WellWh(BaseModel):
         return self.session.execute(query).scalars().all()
 
 
-class PacBioPagedWellsFactory(WellWh, PagedStatusResponse):
+class PacBioPagedWellsFactory(WellWh, PagedResponse):
     """
     Factory class to create `PacBioPagedWells` objects that correspond to
     the criteria given by the attributes of the object, i.e. `page_size`
-    `page_number` and `qc_flow_status` attributes.
+    `page_number`, and any other criteria that are specified by the
+    arguments of the factory methods of this class.
     """
 
     qcdb_session: Session = Field(
@@ -169,11 +170,11 @@ class PacBioPagedWellsFactory(WellWh, PagedStatusResponse):
         extra = Extra.forbid
         allow_mutation = True
 
-    def create(self) -> PacBioPagedWells:
+    def create(self, qc_flow_status: QcFlowStatusEnum) -> PacBioPagedWells:
         """
         Returns `PacBioPagedWells` object that corresponds to the criteria
-        specified by the `page_size`, `page_number, and `qc_flow_status`
-        attributes.
+        specified by the `page_size`, `page_number` object's attributes and
+        `qc_flow_status` argument of this function..
 
         The `PacBioWell` objects in `wells` attribute of the returned object
         are sorted in a way appropriate for the requested `qc_flow_status`.
@@ -186,27 +187,26 @@ class PacBioPagedWellsFactory(WellWh, PagedStatusResponse):
         """
 
         wells = []
-        if self.qc_flow_status == QcFlowStatusEnum.INBOX:
+        if qc_flow_status == QcFlowStatusEnum.INBOX:
             recent_wells = self.recent_completed_wells()
             wells = self._recent_inbox_wells(recent_wells)
-        elif self.qc_flow_status in [
+        elif qc_flow_status in [
             QcFlowStatusEnum.ABORTED,
             QcFlowStatusEnum.UNKNOWN,
         ]:
-            wells = self._aborted_and_unknown_wells()
+            wells = self._aborted_and_unknown_wells(qc_flow_status)
         else:
-            wells = self._get_wells()
+            wells = self._get_wells(qc_flow_status)
             self._add_tracking_info(wells)
 
         return PacBioPagedWells(
             page_number=self.page_number,
             page_size=self.page_size,
             total_number_of_items=self.total_number_of_items,
-            qc_flow_status=self.qc_flow_status,
             wells=wells,
         )
 
-    def _build_query4status(self):
+    def _build_query4status(self, qc_flow_status: QcFlowStatusEnum):
 
         # TODO: add filtering by the seq platform
 
@@ -220,23 +220,27 @@ class PacBioPagedWellsFactory(WellWh, PagedStatusResponse):
             .order_by(QcState.date_updated.desc())
         )
         # Add status-specific part of the query.
-        return query.where(self.FILTERS[self.qc_flow_status.name])
+        return query.where(self.FILTERS[qc_flow_status.name])
 
-    def _retrieve_qc_states(self):
+    def _retrieve_qc_states(self, qc_flow_status: QcFlowStatusEnum):
 
-        states = self.qcdb_session.execute(self._build_query4status()).scalars().all()
+        states = (
+            self.qcdb_session.execute(self._build_query4status(qc_flow_status))
+            .scalars()
+            .all()
+        )
         # Save the number of retrieved rows - needed to page correctly,
         # also needed by the client to correctly set up the paging widget.
         self.total_number_of_items = len(states)
         # Return the states for the wells we were asked to fetch, max - page_size, min - 0.
         return self.slice_data(states)
 
-    def _get_wells(self) -> List[PacBioWell]:
+    def _get_wells(self, qc_flow_status: QcFlowStatusEnum) -> List[PacBioWell]:
 
         # Note that the run name and well label are sourced from the QC database.
         # They'd better be correct there!
         wells = []
-        for qc_state in self._retrieve_qc_states():
+        for qc_state in self._retrieve_qc_states(qc_flow_status):
             sub_product = qc_state.seq_product.product_layout[0].sub_product
             # TODO: consider adding from_orm method to PacBioWell
             wells.append(
@@ -289,12 +293,12 @@ class PacBioPagedWellsFactory(WellWh, PagedStatusResponse):
 
         return self._well_models(inbox_wells)
 
-    def _aborted_and_unknown_wells(self):
+    def _aborted_and_unknown_wells(self, qc_flow_status: QcFlowStatusEnum):
 
         wells = (
             self.session.execute(
                 select(PacBioRunWellMetrics)
-                .where(self.FILTERS[self.qc_flow_status.name])
+                .where(self.FILTERS[qc_flow_status.name])
                 .order_by(
                     PacBioRunWellMetrics.pac_bio_run_name,
                     PacBioRunWellMetrics.well_label,
@@ -307,19 +311,24 @@ class PacBioPagedWellsFactory(WellWh, PagedStatusResponse):
         # Save the number of retrieved rows.
         self.total_number_of_items = len(wells)
 
-        return self._well_models(self.slice_data(wells))
+        return self._well_models(self.slice_data(wells), True)
 
-    def _well_models(self, db_wells_list):
+    def _well_models(
+        self,
+        db_wells_list: List[PacBioRunWellMetrics],
+        qc_state_applicable: bool = False,
+    ):
 
         # Normally QC data is not available for the inbox, aborted, etc.
         # wells. If some well with a non-inbox status has QC state assigned,
         # the same well will also be retrieved by the 'in progress' or
         # 'on hold' or 'qc complete' queries. However, it is useful to display
-        # the QC state if it is available.
+        # the QC state if it is available. The `qc_state_applicable` argument
+        # is a hint to fetch QC state.
         pb_wells = []
         for db_well in db_wells_list:
             attrs = {"run_name": db_well.pac_bio_run_name, "label": db_well.well_label}
-            if self.qc_flow_status != QcFlowStatusEnum.INBOX:
+            if qc_state_applicable:
                 qc_state = WellQc(
                     session=self.qcdb_session,
                     run_name=db_well.pac_bio_run_name,

--- a/lang_qc/endpoints/pacbio_well.py
+++ b/lang_qc/endpoints/pacbio_well.py
@@ -49,9 +49,10 @@ router = APIRouter(
     description="""
          Taking an optional 'qc_status' as a query parameter, returns a list of
          runs with wells filtered by status. The default qc status is 'inbox'.
-         Possible values for this parameter are defined in QcFlowStatusEnum. For the
-         inbox view an optional 'weeks' query parameter can be used, it defaults
-         to one week and defines the number of weeks to look back.
+         Possible values for this parameter are defined in QcFlowStatusEnum.
+
+         The list is paged according to non-optional parameters `page_size` and
+         `page_number`.
     """,
     responses={
         status.HTTP_422_UNPROCESSABLE_ENTITY: {
@@ -74,8 +75,7 @@ def get_wells_filtered_by_status(
         mlwh_session=mlwh_session,
         page_size=page_size,
         page_number=page_number,
-        qc_flow_status=qc_status,
-    ).create()
+    ).create(qc_status)
 
 
 @router.get(

--- a/lang_qc/endpoints/pacbio_well.py
+++ b/lang_qc/endpoints/pacbio_well.py
@@ -75,7 +75,7 @@ def get_wells_filtered_by_status(
         mlwh_session=mlwh_session,
         page_size=page_size,
         page_number=page_number,
-    ).create(qc_status)
+    ).create_for_qc_status(qc_status)
 
 
 @router.get(

--- a/lang_qc/models/pacbio/well.py
+++ b/lang_qc/models/pacbio/well.py
@@ -29,7 +29,7 @@ from sqlalchemy.orm import Session
 from lang_qc.db.helper.well import WellQc
 from lang_qc.models.pacbio.experiment import PacBioExperiment
 from lang_qc.models.pacbio.qc_data import QCDataWell
-from lang_qc.models.pager import PagedStatusResponse
+from lang_qc.models.pager import PagedResponse
 from lang_qc.models.qc_state import QcState
 
 
@@ -81,7 +81,7 @@ class PacBioWell(BaseModel, extra=Extra.forbid):
         self.well_status = db_well.well_status
 
 
-class PacBioPagedWells(PagedStatusResponse, extra=Extra.forbid):
+class PacBioPagedWells(PagedResponse, extra=Extra.forbid):
     """
     A response model for paged data about PacBio wells.
     """
@@ -90,9 +90,8 @@ class PacBioPagedWells(PagedStatusResponse, extra=Extra.forbid):
         default=[],
         title="A list of PacBioWell objects",
         description="""
-        A list of `PacBioWell` objects that corresponds to the QC flow status
-        given by the `qc_flow_status` attribute and the page number and size
-        specified by the `page_size` and `page_number` attributes.
+        A list of `PacBioWell` objects that corresponds to the page number
+        and size specified by the `page_size` and `page_number` attributes.
         """,
     )
 

--- a/lang_qc/models/pager.py
+++ b/lang_qc/models/pager.py
@@ -21,8 +21,6 @@ from typing import List
 
 from pydantic import BaseModel, Field, PositiveInt
 
-from lang_qc.models.qc_flow_status import QcFlowStatusEnum
-
 
 class PagedResponse(BaseModel):
     """
@@ -65,14 +63,3 @@ class PagedResponse(BaseModel):
         from_number = self.page_size * (self.page_number - 1)
         to_number = from_number + self.page_size
         return data[from_number:to_number]
-
-
-class PagedStatusResponse(PagedResponse):
-    """
-    A response model for paged data that relates to a particular QC flow
-    status, described by the `qc_flow_status` attribute.
-    """
-
-    qc_flow_status: QcFlowStatusEnum = Field(
-        title="QC flow status", description="QC flow status used for the selection."
-    )

--- a/tests/endpoints/test_filtered_wells.py
+++ b/tests/endpoints/test_filtered_wells.py
@@ -43,7 +43,7 @@ def test_qc_complete_filter(test_client: TestClient, load_data4well_retrieval):
     response = test_client.get(
         "/pacbio/wells?page_size=10&page_number=1&qc_status=" + status
     )
-    _assert_filtered_results(response, expected_data, 10, 1, num_total, status)
+    _assert_filtered_results(response, expected_data, 10, 1, num_total)
     for well in response.json()["wells"]:
         assert well["run_start_time"] is not None
         assert well["run_complete_time"] is not None
@@ -53,19 +53,19 @@ def test_qc_complete_filter(test_client: TestClient, load_data4well_retrieval):
     response = test_client.get(
         "/pacbio/wells?page_size=10&page_number=2&qc_status=" + status
     )
-    _assert_filtered_results(response, [], 10, 2, num_total, status)
+    _assert_filtered_results(response, [], 10, 2, num_total)
 
     response = test_client.get(
         "/pacbio/wells?page_size=2&page_number=1&qc_status=" + status
     )
     ed = expected_data[0:2]
-    _assert_filtered_results(response, ed, 2, 1, num_total, status)
+    _assert_filtered_results(response, ed, 2, 1, num_total)
 
     response = test_client.get(
         "/pacbio/wells?page_size=2&page_number=2&qc_status=" + status
     )
     ed = expected_data[2:]
-    _assert_filtered_results(response, ed, 2, 2, num_total, status)
+    _assert_filtered_results(response, ed, 2, 2, num_total)
 
 
 def test_on_hold_filter(test_client: TestClient, load_data4well_retrieval):
@@ -81,7 +81,7 @@ def test_on_hold_filter(test_client: TestClient, load_data4well_retrieval):
     response = test_client.get(
         "/pacbio/wells?page_size=10&page_number=1&qc_status=" + status
     )
-    _assert_filtered_results(response, expected_data, 10, 1, num_total, status)
+    _assert_filtered_results(response, expected_data, 10, 1, num_total)
 
     response = test_client.get(
         "/pacbio/wells?page_size=10&page_number=2&qc_status=" + status
@@ -92,7 +92,7 @@ def test_on_hold_filter(test_client: TestClient, load_data4well_retrieval):
         "/pacbio/wells?page_size=2&page_number=1&qc_status=" + status
     )
     ed = expected_data[0:2]
-    _assert_filtered_results(response, ed, 2, 1, num_total, status)
+    _assert_filtered_results(response, ed, 2, 1, num_total)
 
 
 def test_in_progress_filter(test_client: TestClient, load_data4well_retrieval):
@@ -115,16 +115,12 @@ def test_in_progress_filter(test_client: TestClient, load_data4well_retrieval):
     response = test_client.get(
         "/pacbio/wells?qc_status=in_progress&page_size=5&page_number=1"
     )
-    _assert_filtered_results(
-        response, expected_data[:5], 5, 1, num_total, "in_progress"
-    )
+    _assert_filtered_results(response, expected_data[:5], 5, 1, num_total)
 
     response = test_client.get(
         "/pacbio/wells?qc_status=in_progress&page_size=5&page_number=2"
     )
-    _assert_filtered_results(
-        response, expected_data[5:], 5, 2, num_total, "in_progress"
-    )
+    _assert_filtered_results(response, expected_data[5:], 5, 2, num_total)
 
 
 def test_inbox_filter(test_client: TestClient, load_data4well_retrieval):
@@ -145,12 +141,12 @@ def test_inbox_filter(test_client: TestClient, load_data4well_retrieval):
     num_total = len(expected_data)
 
     response = test_client.get("/pacbio/wells?page_size=100&page_number=1")
-    _assert_filtered_results(response, expected_data, 100, 1, num_total, status)
+    _assert_filtered_results(response, expected_data, 100, 1, num_total)
 
     response = test_client.get(
         "/pacbio/wells?qc_status=inbox&page_size=100&page_number=1"
     )
-    _assert_filtered_results(response, expected_data, 100, 1, num_total, status)
+    _assert_filtered_results(response, expected_data, 100, 1, num_total)
 
     response = test_client.get(
         "/pacbio/wells?page_size=100&page_number=2&qc_status=inbox"
@@ -161,31 +157,31 @@ def test_inbox_filter(test_client: TestClient, load_data4well_retrieval):
         "/pacbio/wells?page_size=2&page_number=1&qc_status=inbox"
     )
     ed = expected_data[0:2]
-    _assert_filtered_results(response, ed, 2, 1, num_total, status)
+    _assert_filtered_results(response, ed, 2, 1, num_total)
 
     response = test_client.get(
         "/pacbio/wells?page_size=2&page_number=2&qc_status=inbox"
     )
     ed = expected_data[2:4]
-    _assert_filtered_results(response, ed, 2, 2, num_total, status)
+    _assert_filtered_results(response, ed, 2, 2, num_total)
 
     response = test_client.get(
         "/pacbio/wells?page_size=2&page_number=4&qc_status=inbox"
     )
     ed = expected_data[6:]
-    _assert_filtered_results(response, ed, 2, 4, num_total, status)
+    _assert_filtered_results(response, ed, 2, 4, num_total)
 
     response = test_client.get(
         "/pacbio/wells?page_size=3&page_number=2&qc_status=inbox"
     )
     ed = expected_data[3:6]
-    _assert_filtered_results(response, ed, 3, 2, num_total, status)
+    _assert_filtered_results(response, ed, 3, 2, num_total)
 
     response = test_client.get(
         "/pacbio/wells?page_size=3&page_number=3&qc_status=inbox"
     )
     ed = expected_data[6:]
-    _assert_filtered_results(response, ed, 3, 3, num_total, status)
+    _assert_filtered_results(response, ed, 3, 3, num_total)
 
 
 def test_unknown_filter(test_client: TestClient, load_data4well_retrieval):
@@ -200,17 +196,17 @@ def test_unknown_filter(test_client: TestClient, load_data4well_retrieval):
     response = test_client.get(
         "/pacbio/wells?qc_status=unknown&page_size=5&page_number=1"
     )
-    _assert_filtered_results(response, expected_data, 5, 1, num_total, "unknown")
+    _assert_filtered_results(response, expected_data, 5, 1, num_total)
 
     response = test_client.get(
         "/pacbio/wells?qc_status=unknown&page_size=1&page_number=2"
     )
-    _assert_filtered_results(response, expected_data[1:], 1, 2, num_total, "unknown")
+    _assert_filtered_results(response, expected_data[1:], 1, 2, num_total)
 
     response = test_client.get(
         "/pacbio/wells?qc_status=unknown&page_size=1&page_number=4"
     )
-    _assert_filtered_results(response, [], 1, 4, num_total, "unknown")
+    _assert_filtered_results(response, [], 1, 4, num_total)
 
 
 def test_aborted_filter(test_client: TestClient, load_data4well_retrieval):
@@ -229,21 +225,21 @@ def test_aborted_filter(test_client: TestClient, load_data4well_retrieval):
     response = test_client.get(
         "/pacbio/wells?qc_status=aborted&page_size=6&page_number=1"
     )
-    _assert_filtered_results(response, expected_data, 6, 1, num_total, "aborted")
+    _assert_filtered_results(response, expected_data, 6, 1, num_total)
 
     response = test_client.get(
         "/pacbio/wells?qc_status=aborted&page_size=2&page_number=2"
     )
-    _assert_filtered_results(response, expected_data[2:4], 2, 2, num_total, "aborted")
+    _assert_filtered_results(response, expected_data[2:4], 2, 2, num_total)
 
     response = test_client.get(
         "/pacbio/wells?qc_status=aborted&page_size=10&page_number=100"
     )
-    _assert_filtered_results(response, [], 10, 100, num_total, "aborted")
+    _assert_filtered_results(response, [], 10, 100, num_total)
 
 
 def _assert_filtered_results(
-    response, expected_data, page_size, page_number, total_number, qc_flow_status
+    response, expected_data, page_size, page_number, total_number
 ):
     """Convenience function to test the result of filtered well endpoint.
 
@@ -258,7 +254,6 @@ def _assert_filtered_results(
     assert resp["page_size"] == page_size
     assert resp["page_number"] == page_number
     assert resp["total_number_of_items"] == total_number
-    assert resp["qc_flow_status"] == qc_flow_status
     assert type(resp["wells"]) is list
 
     actual_data = []

--- a/tests/test_wells4status_retrieval.py
+++ b/tests/test_wells4status_retrieval.py
@@ -17,9 +17,8 @@ def test_query(qcdb_test_session, mlwhdb_test_session, load_data4well_retrieval)
         mlwh_session=mlwhdb_test_session,
         page_size=10,
         page_number=1,
-        qc_flow_status=QcFlowStatusEnum.ON_HOLD,
     )
-    query = factory._build_query4status()
+    query = factory._build_query4status(QcFlowStatusEnum.ON_HOLD)
     states = qcdb_test_session.execute(query).scalars().all()
     assert len(states) == 2
     # The results should be sorted by the update date in a descending order.
@@ -37,9 +36,8 @@ def test_query(qcdb_test_session, mlwhdb_test_session, load_data4well_retrieval)
         mlwh_session=mlwhdb_test_session,
         page_size=10,
         page_number=1,
-        qc_flow_status=QcFlowStatusEnum.IN_PROGRESS,
     )
-    query = factory._build_query4status()
+    query = factory._build_query4status(QcFlowStatusEnum.IN_PROGRESS)
     states = qcdb_test_session.execute(query).scalars().all()
     expected_data = [
         ["Failed", "2022-02-15 10:42:33"],
@@ -68,9 +66,8 @@ def test_query(qcdb_test_session, mlwhdb_test_session, load_data4well_retrieval)
         mlwh_session=mlwhdb_test_session,
         page_size=10,
         page_number=1,
-        qc_flow_status=QcFlowStatusEnum.QC_COMPLETE,
     )
-    query = factory._build_query4status()
+    query = factory._build_query4status(QcFlowStatusEnum.QC_COMPLETE)
     states = qcdb_test_session.execute(query).scalars().all()
     expected_data = [
         ["Failed, SMRT cell", "2022-12-07 15:23:56"],
@@ -104,12 +101,10 @@ def test_inbox_wells_retrieval(
         mlwh_session=mlwhdb_test_session,
         page_size=10,
         page_number=1,
-        qc_flow_status=status,
-    ).create()
+    ).create(status)
     assert isinstance(paged_wells, PacBioPagedWells)
     assert paged_wells.page_size == 10
     assert paged_wells.page_number == 1
-    assert paged_wells.qc_flow_status == status
     assert paged_wells.total_number_of_items == 8
     assert len(paged_wells.wells) == 8
 
@@ -118,12 +113,10 @@ def test_inbox_wells_retrieval(
         mlwh_session=mlwhdb_test_session,
         page_size=10,
         page_number=2,
-        qc_flow_status=status,
-    ).create()
+    ).create(status)
     assert isinstance(paged_wells, PacBioPagedWells)
     assert paged_wells.page_size == 10
     assert paged_wells.page_number == 2
-    assert paged_wells.qc_flow_status == status
     assert paged_wells.total_number_of_items == 8
     assert len(paged_wells.wells) == 0
 
@@ -132,12 +125,10 @@ def test_inbox_wells_retrieval(
         mlwh_session=mlwhdb_test_session,
         page_size=3,
         page_number=3,
-        qc_flow_status=status,
-    ).create()
+    ).create(status)
     assert isinstance(paged_wells, PacBioPagedWells)
     assert paged_wells.page_size == 3
     assert paged_wells.page_number == 3
-    assert paged_wells.qc_flow_status == status
     assert paged_wells.total_number_of_items == 8
     assert len(paged_wells.wells) == 2
 
@@ -193,13 +184,11 @@ def test_paged_retrieval(
             mlwh_session=mlwhdb_test_session,
             page_size=10,
             page_number=1,
-            qc_flow_status=status,
         )
-        paged_wells = factory.create()
+        paged_wells = factory.create(status)
         assert isinstance(paged_wells, PacBioPagedWells)
         assert paged_wells.page_size == 10
         assert paged_wells.page_number == 1
-        assert paged_wells.qc_flow_status == status
         total_number_of_items = paged_wells.total_number_of_items
         assert total_number_of_items == expected_page_details[status.name]
         assert len(paged_wells.wells) == total_number_of_items
@@ -209,13 +198,11 @@ def test_paged_retrieval(
             mlwh_session=mlwhdb_test_session,
             page_size=2,
             page_number=10,
-            qc_flow_status=status,
         )
-        paged_wells = factory.create()
+        paged_wells = factory.create(status)
         assert isinstance(paged_wells, PacBioPagedWells)
         assert paged_wells.page_size == 2
         assert paged_wells.page_number == 10
-        assert paged_wells.qc_flow_status == status
         assert paged_wells.total_number_of_items == total_number_of_items
         assert len(paged_wells.wells) == 0
 
@@ -224,13 +211,11 @@ def test_paged_retrieval(
             mlwh_session=mlwhdb_test_session,
             page_size=1,
             page_number=1,
-            qc_flow_status=status,
         )
-        paged_wells = factory.create()
+        paged_wells = factory.create(status)
         assert isinstance(paged_wells, PacBioPagedWells)
         assert paged_wells.page_size == 1
         assert paged_wells.page_number == 1
-        assert paged_wells.qc_flow_status == status
         assert paged_wells.total_number_of_items == total_number_of_items
         assert len(paged_wells.wells) == 1
 
@@ -239,13 +224,11 @@ def test_paged_retrieval(
             mlwh_session=mlwhdb_test_session,
             page_size=1,
             page_number=2,
-            qc_flow_status=status,
         )
-        paged_wells = factory.create()
+        paged_wells = factory.create(status)
         assert isinstance(paged_wells, PacBioPagedWells)
         assert paged_wells.page_size == 1
         assert paged_wells.page_number == 2
-        assert paged_wells.qc_flow_status == status
         assert paged_wells.total_number_of_items == total_number_of_items
         assert len(paged_wells.wells) == 1
 
@@ -254,13 +237,11 @@ def test_paged_retrieval(
             mlwh_session=mlwhdb_test_session,
             page_size=10,
             page_number=2,
-            qc_flow_status=status,
         )
-        paged_wells = factory.create()
+        paged_wells = factory.create(status)
         assert isinstance(paged_wells, PacBioPagedWells)
         assert paged_wells.page_size == 10
         assert paged_wells.page_number == 2
-        assert paged_wells.qc_flow_status == status
         assert paged_wells.total_number_of_items == total_number_of_items
         assert len(paged_wells.wells) == 0
 
@@ -270,13 +251,11 @@ def test_paged_retrieval(
         mlwh_session=mlwhdb_test_session,
         page_size=3,
         page_number=2,
-        qc_flow_status=status,
     )
-    paged_wells = factory.create()
+    paged_wells = factory.create(status)
     assert isinstance(paged_wells, PacBioPagedWells)
     assert paged_wells.page_size == 3
     assert paged_wells.page_number == 2
-    assert paged_wells.qc_flow_status == status
     assert paged_wells.total_number_of_items == 4
     assert len(paged_wells.wells) == 1
 
@@ -290,9 +269,8 @@ def test_fully_retrieved_data(
         mlwh_session=mlwhdb_test_session,
         page_size=5,
         page_number=1,
-        qc_flow_status=QcFlowStatusEnum.QC_COMPLETE,
     )
-    paged_wells = factory.create()
+    paged_wells = factory.create(QcFlowStatusEnum.QC_COMPLETE)
 
     well = paged_wells.wells[0]
     assert isinstance(well, PacBioWell)
@@ -348,9 +326,8 @@ def test_partially_retrieved_data(
         mlwh_session=mlwhdb_test_session,
         page_size=5,
         page_number=2,
-        qc_flow_status=QcFlowStatusEnum.IN_PROGRESS,
     )
-    paged_wells = factory.create()
+    paged_wells = factory.create(QcFlowStatusEnum.IN_PROGRESS)
     well = paged_wells.wells[2]
     assert isinstance(well, PacBioWell)
     assert well.run_name == "TRACTION_RUN_1"

--- a/tests/test_wells4status_retrieval.py
+++ b/tests/test_wells4status_retrieval.py
@@ -101,7 +101,7 @@ def test_inbox_wells_retrieval(
         mlwh_session=mlwhdb_test_session,
         page_size=10,
         page_number=1,
-    ).create(status)
+    ).create_for_qc_status(status)
     assert isinstance(paged_wells, PacBioPagedWells)
     assert paged_wells.page_size == 10
     assert paged_wells.page_number == 1
@@ -113,7 +113,7 @@ def test_inbox_wells_retrieval(
         mlwh_session=mlwhdb_test_session,
         page_size=10,
         page_number=2,
-    ).create(status)
+    ).create_for_qc_status(status)
     assert isinstance(paged_wells, PacBioPagedWells)
     assert paged_wells.page_size == 10
     assert paged_wells.page_number == 2
@@ -125,7 +125,7 @@ def test_inbox_wells_retrieval(
         mlwh_session=mlwhdb_test_session,
         page_size=3,
         page_number=3,
-    ).create(status)
+    ).create_for_qc_status(status)
     assert isinstance(paged_wells, PacBioPagedWells)
     assert paged_wells.page_size == 3
     assert paged_wells.page_number == 3
@@ -185,7 +185,7 @@ def test_paged_retrieval(
             page_size=10,
             page_number=1,
         )
-        paged_wells = factory.create(status)
+        paged_wells = factory.create_for_qc_status(status)
         assert isinstance(paged_wells, PacBioPagedWells)
         assert paged_wells.page_size == 10
         assert paged_wells.page_number == 1
@@ -199,7 +199,7 @@ def test_paged_retrieval(
             page_size=2,
             page_number=10,
         )
-        paged_wells = factory.create(status)
+        paged_wells = factory.create_for_qc_status(status)
         assert isinstance(paged_wells, PacBioPagedWells)
         assert paged_wells.page_size == 2
         assert paged_wells.page_number == 10
@@ -212,7 +212,7 @@ def test_paged_retrieval(
             page_size=1,
             page_number=1,
         )
-        paged_wells = factory.create(status)
+        paged_wells = factory.create_for_qc_status(status)
         assert isinstance(paged_wells, PacBioPagedWells)
         assert paged_wells.page_size == 1
         assert paged_wells.page_number == 1
@@ -225,7 +225,7 @@ def test_paged_retrieval(
             page_size=1,
             page_number=2,
         )
-        paged_wells = factory.create(status)
+        paged_wells = factory.create_for_qc_status(status)
         assert isinstance(paged_wells, PacBioPagedWells)
         assert paged_wells.page_size == 1
         assert paged_wells.page_number == 2
@@ -238,7 +238,7 @@ def test_paged_retrieval(
             page_size=10,
             page_number=2,
         )
-        paged_wells = factory.create(status)
+        paged_wells = factory.create_for_qc_status(status)
         assert isinstance(paged_wells, PacBioPagedWells)
         assert paged_wells.page_size == 10
         assert paged_wells.page_number == 2
@@ -252,7 +252,7 @@ def test_paged_retrieval(
         page_size=3,
         page_number=2,
     )
-    paged_wells = factory.create(status)
+    paged_wells = factory.create_for_qc_status(status)
     assert isinstance(paged_wells, PacBioPagedWells)
     assert paged_wells.page_size == 3
     assert paged_wells.page_number == 2
@@ -270,7 +270,7 @@ def test_fully_retrieved_data(
         page_size=5,
         page_number=1,
     )
-    paged_wells = factory.create(QcFlowStatusEnum.QC_COMPLETE)
+    paged_wells = factory.create_for_qc_status(QcFlowStatusEnum.QC_COMPLETE)
 
     well = paged_wells.wells[0]
     assert isinstance(well, PacBioWell)
@@ -327,7 +327,7 @@ def test_partially_retrieved_data(
         page_size=5,
         page_number=2,
     )
-    paged_wells = factory.create(QcFlowStatusEnum.IN_PROGRESS)
+    paged_wells = factory.create_for_qc_status(QcFlowStatusEnum.IN_PROGRESS)
     well = paged_wells.wells[2]
     assert isinstance(well, PacBioWell)
     assert well.run_name == "TRACTION_RUN_1"


### PR DESCRIPTION
qc_flow_status key was a part of the response to a request to fetch wells for a particular QC flow status. This key is not being used by the front end code. Its presence makes the response model less generic, i.e. not usable for requests that are not associated with any particular QC flow status.