### PR TITLE
Later el-plus rendering of <button> seems to have a typo

### DIFF
--- a/frontend/src/components/__tests__/QcWidget.spec.js
+++ b/frontend/src/components/__tests__/QcWidget.spec.js
@@ -85,7 +85,7 @@ describe('QC widgets render with no prior QC state, i.e. pending/ready', () => {
 
     test('Submit button is disabled', () => {
         let button = wrapper.get('button');
-        expect(button.attributes('aria-disabled')).toEqual('true');
+        expect(button.attributes('disabled')).toBe("");
     });
 
     test('Disable via prop turns off all controls', async () => {


### PR DESCRIPTION
"aria-disabled" becomes "ariadisabled" with latest release in NPM. Change to checking for a different disabled attribute