### PR TITLE
Added local ORM classes for mlwh database.

### DIFF
--- a/lang_qc/db/helper/wells.py
+++ b/lang_qc/db/helper/wells.py
@@ -23,12 +23,12 @@ import logging
 from datetime import date, datetime, timedelta
 from typing import ClassVar, List
 
-from ml_warehouse.schema import PacBioRunWellMetrics
 from pydantic import BaseModel, Extra, Field
 from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import Session
 
 from lang_qc.db.helper.well import WellQc
+from lang_qc.db.mlwh_schema import PacBioRunWellMetrics
 from lang_qc.db.qc_schema import QcState, QcStateDict, QcType
 from lang_qc.models.pacbio.well import PacBioPagedWells, PacBioWell
 from lang_qc.models.pager import PagedResponse

--- a/lang_qc/db/mlwh_schema.py
+++ b/lang_qc/db/mlwh_schema.py
@@ -28,7 +28,6 @@ from sqlalchemy.dialects.mysql import VARCHAR as mysqlVARCHAR
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
-# metadata = Base.metadata
 
 
 class Sample(Base):

--- a/lang_qc/db/mlwh_schema.py
+++ b/lang_qc/db/mlwh_schema.py
@@ -1,0 +1,548 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2023 Genome Research Ltd. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# @author mgcam <mg8@sanger.ac.uk>
+
+from sqlalchemy import Column, Computed, DateTime, ForeignKey, Index, String, Text, text
+from sqlalchemy.dialects.mysql import BIGINT as mysqlBIGINT
+from sqlalchemy.dialects.mysql import CHAR as mysqlCHAR
+from sqlalchemy.dialects.mysql import FLOAT as mysqlFLOAT
+from sqlalchemy.dialects.mysql import INTEGER as mysqlINTEGER
+from sqlalchemy.dialects.mysql import SMALLINT as mysqlSMALLINT
+from sqlalchemy.dialects.mysql import TINYINT as mysqlTINYINT
+from sqlalchemy.dialects.mysql import VARCHAR as mysqlVARCHAR
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+# metadata = Base.metadata
+
+
+class Sample(Base):
+    __tablename__ = "sample"
+    __table_args__ = (
+        Index(
+            "index_sample_on_id_sample_lims_and_id_lims",
+            "id_sample_lims",
+            "id_lims",
+            unique=True,
+        ),
+    )
+
+    id_sample_tmp = Column(
+        mysqlINTEGER(10, unsigned=True),
+        primary_key=True,
+        comment="Internal to this database id, value can change",
+    )
+    id_lims = Column(
+        String(10, "utf8_unicode_ci"),
+        nullable=False,
+        comment="LIM system identifier, e.g. CLARITY-GCLP, SEQSCAPE",
+    )
+    id_sample_lims = Column(
+        String(20, "utf8_unicode_ci"),
+        nullable=False,
+        comment="LIMS-specific sample identifier",
+    )
+    consent_withdrawn = Column(
+        mysqlTINYINT(1), nullable=False, server_default=text("'0'")
+    )
+    uuid_sample_lims = Column(
+        String(36, "utf8_unicode_ci"), unique=True, comment="LIMS-specific sample uuid"
+    )
+    name = Column(String(255, "utf8_unicode_ci"), index=True)
+    reference_genome = Column(String(255, "utf8_unicode_ci"))
+    organism = Column(String(255, "utf8_unicode_ci"))
+    accession_number = Column(String(50, "utf8_unicode_ci"), index=True)
+    common_name = Column(String(255, "utf8_unicode_ci"))
+    description = Column(Text(collation="utf8_unicode_ci"))
+    taxon_id = Column(mysqlINTEGER(6, unsigned=True))
+    sanger_sample_id = Column(String(255, "utf8_unicode_ci"), index=True)
+    control = Column(mysqlTINYINT(1))
+    supplier_name = Column(String(255, "utf8_unicode_ci"), index=True)
+    public_name = Column(String(255, "utf8_unicode_ci"))
+    strain = Column(String(255, "utf8_unicode_ci"))
+    control_type = Column(String(255, "utf8_unicode_ci"))
+    sample_type = Column(String(255, "utf8_unicode_ci"))
+
+    pac_bio_run = relationship("PacBioRun", back_populates="sample")
+
+
+class Study(Base):
+    __tablename__ = "study"
+    __table_args__ = (
+        Index(
+            "study_id_lims_id_study_lims_index", "id_lims", "id_study_lims", unique=True
+        ),
+    )
+
+    id_study_tmp = Column(
+        mysqlINTEGER(10, unsigned=True),
+        primary_key=True,
+        comment="Internal to this database id, value can change",
+    )
+    id_lims = Column(
+        String(10, "utf8_unicode_ci"),
+        nullable=False,
+        comment="LIM system identifier, e.g. GCLP-CLARITY, SEQSCAPE",
+    )
+    id_study_lims = Column(
+        String(20, "utf8_unicode_ci"),
+        nullable=False,
+        comment="LIMS-specific study identifier",
+    )
+    remove_x_and_autosomes = Column(
+        mysqlTINYINT(1), nullable=False, server_default=text("'0'")
+    )
+    aligned = Column(mysqlTINYINT(1), nullable=False, server_default=text("'1'"))
+    separate_y_chromosome_data = Column(
+        mysqlTINYINT(1), nullable=False, server_default=text("'0'")
+    )
+    uuid_study_lims = Column(
+        String(36, "utf8_unicode_ci"), unique=True, comment="LIMS-specific study uuid"
+    )
+    name = Column(String(255, "utf8_unicode_ci"), index=True)
+    reference_genome = Column(String(255, "utf8_unicode_ci"))
+    accession_number = Column(String(50, "utf8_unicode_ci"), index=True)
+    description = Column(Text(collation="utf8_unicode_ci"))
+    contains_human_dna = Column(mysqlTINYINT(1), comment="Lane may contain human DNA")
+    contaminated_human_dna = Column(
+        mysqlTINYINT(1),
+        comment="Human DNA in the lane is a contaminant and should be removed",
+    )
+    study_title = Column(String(255, "utf8_unicode_ci"))
+    study_visibility = Column(String(255, "utf8_unicode_ci"))
+
+    pac_bio_run = relationship("PacBioRun", back_populates="study")
+
+
+class PacBioRun(Base):
+    __tablename__ = "pac_bio_run"
+    __table_args__ = (
+        Index(
+            "unique_pac_bio_entry",
+            "id_lims",
+            "id_pac_bio_run_lims",
+            "well_label",
+            "comparable_tag_identifier",
+            "comparable_tag2_identifier",
+            unique=True,
+        ),
+    )
+
+    id_pac_bio_tmp = Column(mysqlINTEGER(11), primary_key=True)
+    last_updated = Column(DateTime, nullable=False, comment="Timestamp of last update")
+    recorded_at = Column(
+        DateTime, nullable=False, comment="Timestamp of warehouse update"
+    )
+    id_sample_tmp = Column(
+        ForeignKey("sample.id_sample_tmp"),
+        nullable=False,
+        index=True,
+        comment='Sample id, see "sample.id_sample_tmp"',
+    )
+    id_study_tmp = Column(
+        ForeignKey("study.id_study_tmp"),
+        nullable=False,
+        index=True,
+        comment='Sample id, see "study.id_study_tmp"',
+    )
+    id_pac_bio_run_lims = Column(
+        String(20, "utf8_unicode_ci"),
+        nullable=False,
+        comment="Lims specific identifier for the pacbio run",
+    )
+    cost_code = Column(
+        String(20, "utf8_unicode_ci"), nullable=False, comment="Valid WTSI cost-code"
+    )
+    id_lims = Column(
+        String(10, "utf8_unicode_ci"), nullable=False, comment="LIM system identifier"
+    )
+    plate_barcode = Column(
+        String(255, "utf8_unicode_ci"),
+        nullable=False,
+        comment="The human readable barcode for the plate loaded onto the machine",
+    )
+    plate_uuid_lims = Column(
+        String(36, "utf8_unicode_ci"), nullable=False, comment="The plate uuid"
+    )
+    well_label = Column(
+        String(255, "utf8_unicode_ci"),
+        nullable=False,
+        comment="The well identifier for the plate, A1-H12",
+    )
+    well_uuid_lims = Column(
+        String(36, "utf8_unicode_ci"), nullable=False, comment="The well uuid"
+    )
+    pac_bio_library_tube_id_lims = Column(
+        String(255, "utf8_unicode_ci"),
+        nullable=False,
+        comment="LIMS specific identifier for originating library tube",
+    )
+    pac_bio_library_tube_uuid = Column(
+        String(255, "utf8_unicode_ci"),
+        nullable=False,
+        comment="The uuid for the originating library tube",
+    )
+    pac_bio_library_tube_name = Column(
+        String(255, "utf8_unicode_ci"),
+        nullable=False,
+        comment="The name of the originating library tube",
+    )
+    pac_bio_run_uuid = Column(
+        String(36, "utf8_unicode_ci"), comment="Uuid identifier for the pacbio run"
+    )
+    tag_identifier = Column(
+        String(30, "utf8_unicode_ci"),
+        comment="Tag index within tag set, NULL if untagged",
+    )
+    tag_sequence = Column(String(30, "utf8_unicode_ci"), comment="Tag sequence for tag")
+    tag_set_id_lims = Column(
+        String(20, "utf8_unicode_ci"),
+        comment="LIMs-specific identifier of the tag set for tag",
+    )
+    tag_set_name = Column(
+        String(100, "utf8_unicode_ci"), comment="WTSI-wide tag set name for tag"
+    )
+    tag2_sequence = Column(String(30, "utf8_unicode_ci"))
+    tag2_set_id_lims = Column(String(20, "utf8_unicode_ci"))
+    tag2_set_name = Column(String(100, "utf8_unicode_ci"))
+    tag2_identifier = Column(String(30, "utf8_unicode_ci"))
+    pac_bio_library_tube_legacy_id = Column(
+        mysqlINTEGER(11), comment="Legacy library_id for backwards compatibility."
+    )
+    library_created_at = Column(DateTime, comment="Timestamp of library creation")
+    pac_bio_run_name = Column(String(255, "utf8_unicode_ci"), comment="Name of the run")
+    pipeline_id_lims = Column(
+        String(60, "utf8_unicode_ci"),
+        comment="""LIMS-specific pipeline identifier that unambiguously defines
+        library type (eg. Sequel-v1, IsoSeq-v1)""",
+    )
+    comparable_tag_identifier = Column(
+        String(255, "utf8_unicode_ci"),
+        Computed("(ifnull(`tag_identifier`,-(1)))", persisted=False),
+    )
+    comparable_tag2_identifier = Column(
+        String(255, "utf8_unicode_ci"),
+        Computed("(ifnull(`tag2_identifier`,-(1)))", persisted=False),
+    )
+
+    sample = relationship("Sample", back_populates="pac_bio_run")
+    study = relationship("Study", back_populates="pac_bio_run")
+    pac_bio_product_metrics = relationship(
+        "PacBioProductMetrics", back_populates="pac_bio_run"
+    )
+
+
+class PacBioRunWellMetrics(Base):
+    __tablename__ = "pac_bio_run_well_metrics"
+    __table_args__ = (
+        Index(
+            "pac_bio_metrics_run_well", "pac_bio_run_name", "well_label", unique=True
+        ),
+        Index("pb_rw_qc_state_index", "qc_seq_state", "qc_seq_state_is_final"),
+        {
+            "comment": "Status and run information by well and some basic QC data from "
+            "SMRT Link"
+        },
+    )
+
+    id_pac_bio_rw_metrics_tmp = Column(mysqlINTEGER(11), primary_key=True)
+    pac_bio_run_name = Column(
+        mysqlVARCHAR(255, charset="utf8", collation="utf8_unicode_ci"),
+        nullable=False,
+        comment="Lims specific identifier for the pacbio run",
+    )
+    well_label = Column(
+        mysqlVARCHAR(255, charset="utf8", collation="utf8_unicode_ci"),
+        nullable=False,
+        comment="The well identifier for the plate, A1-H12",
+    )
+    instrument_type = Column(
+        mysqlVARCHAR(32, charset="utf8", collation="utf8_unicode_ci"),
+        nullable=False,
+        comment="The instrument type e.g. Sequel",
+    )
+    id_pac_bio_product = Column(
+        mysqlCHAR(64, charset="utf8", collation="utf8_unicode_ci"),
+        nullable=False,
+        unique=True,
+        comment="Product id",
+    )
+    qc_seq_state = Column(String(255), comment="Current sequencing QC state")
+    qc_seq_state_is_final = Column(
+        mysqlTINYINT(1),
+        comment="A flag marking the sequencing QC state as final (1) or not final (0)",
+    )
+    qc_seq_date = Column(
+        DateTime,
+        index=True,
+        comment="The date the current sequencing QC state was assigned",
+    )
+    qc_seq = Column(
+        mysqlTINYINT(1),
+        comment="The final sequencing QC outcome as 0(failed), 1(passed) or NULL",
+    )
+    instrument_name = Column(
+        mysqlVARCHAR(32, charset="utf8", collation="utf8_unicode_ci"),
+        comment="The instrument name e.g. SQ54097",
+    )
+    chip_type = Column(
+        mysqlVARCHAR(32, charset="utf8", collation="utf8_unicode_ci"),
+        comment="The chip type e.g. 8mChip",
+    )
+    sl_hostname = Column(
+        mysqlVARCHAR(255, charset="utf8", collation="utf8_unicode_ci"),
+        comment="SMRT Link server hostname",
+    )
+    sl_run_uuid = Column(
+        mysqlVARCHAR(36, charset="utf8", collation="utf8_unicode_ci"),
+        comment="SMRT Link specific run uuid",
+    )
+    ts_run_name = Column(
+        mysqlVARCHAR(32, charset="utf8", collation="utf8_unicode_ci"),
+        comment="The PacBio run name",
+    )
+    movie_name = Column(
+        mysqlVARCHAR(32, charset="utf8", collation="utf8_unicode_ci"),
+        index=True,
+        comment="The PacBio movie name",
+    )
+    movie_minutes = Column(
+        mysqlSMALLINT(5, unsigned=True),
+        comment="Movie time (collection time) in minutes",
+    )
+    created_by = Column(
+        mysqlVARCHAR(32, charset="utf8", collation="utf8_unicode_ci"),
+        comment="Created by user name recorded in SMRT Link",
+    )
+    binding_kit = Column(
+        mysqlVARCHAR(255, charset="utf8", collation="utf8_unicode_ci"),
+        comment="Binding kit version",
+    )
+    sequencing_kit = Column(
+        mysqlVARCHAR(255, charset="utf8", collation="utf8_unicode_ci"),
+        comment="Sequencing kit version",
+    )
+    sequencing_kit_lot_number = Column(
+        mysqlVARCHAR(255, charset="utf8", collation="utf8_unicode_ci"),
+        comment="Sequencing Kit lot number",
+    )
+    cell_lot_number = Column(String(32), comment="SMRT Cell Lot Number")
+    ccs_execution_mode = Column(
+        mysqlVARCHAR(32, charset="utf8", collation="utf8_unicode_ci"),
+        index=True,
+        comment="The PacBio ccs exection mode e.g. OnInstument, OffInstument or None",
+    )
+    include_kinetics = Column(
+        mysqlTINYINT(1, unsigned=True),
+        comment="Include kinetics information where ccs is run",
+    )
+    hifi_only_reads = Column(
+        mysqlTINYINT(1, unsigned=True),
+        comment="""CCS was run on the instrument and only HiFi reads were included
+        in the export from the instrument""",
+    )
+    heteroduplex_analysis = Column(
+        mysqlTINYINT(1, unsigned=True),
+        comment="Analysis has been run on the instrument to detect and resolve heteroduplex reads",
+    )
+    loading_conc = Column(
+        mysqlFLOAT(unsigned=True), comment="SMRT Cell loading concentration (pM)"
+    )
+    run_start = Column(DateTime, comment="Timestamp of run started")
+    run_complete = Column(DateTime, index=True, comment="Timestamp of run complete")
+    run_transfer_complete = Column(
+        DateTime, comment="Timestamp of run transfer complete"
+    )
+    run_status = Column(
+        String(32),
+        comment="Last recorded status, primarily to explain runs not completed.",
+    )
+    well_start = Column(DateTime, comment="Timestamp of well started")
+    well_complete = Column(DateTime, index=True, comment="Timestamp of well complete")
+    well_status = Column(
+        String(32),
+        comment="Last recorded status, primarily to explain wells not completed.",
+    )
+    chemistry_sw_version = Column(
+        mysqlVARCHAR(32, charset="utf8", collation="utf8_unicode_ci"),
+        comment="The PacBio chemistry software version",
+    )
+    instrument_sw_version = Column(
+        mysqlVARCHAR(32, charset="utf8", collation="utf8_unicode_ci"),
+        comment="The PacBio instrument software version",
+    )
+    primary_analysis_sw_version = Column(
+        mysqlVARCHAR(32, charset="utf8", collation="utf8_unicode_ci"),
+        comment="The PacBio primary analysis software version",
+    )
+    control_num_reads = Column(
+        mysqlINTEGER(10, unsigned=True), comment="The number of control reads"
+    )
+    control_concordance_mean = Column(
+        mysqlFLOAT(8, 6, unsigned=True),
+        comment="""The average concordance between the control raw reads
+        and the control reference sequence""",
+    )
+    control_concordance_mode = Column(
+        mysqlFLOAT(unsigned=True),
+        comment="""The modal value from the concordance between the control
+        raw reads and the control reference sequence""",
+    )
+    control_read_length_mean = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="The mean polymerase read length of the control reads",
+    )
+    local_base_rate = Column(
+        mysqlFLOAT(8, 6, unsigned=True),
+        comment="The average base incorporation rate, excluding polymerase pausing events",
+    )
+    polymerase_read_bases = Column(
+        mysqlBIGINT(20, unsigned=True),
+        comment="""Calculated by multiplying the number of productive (P1) ZMWs
+        by the mean polymerase read length""",
+    )
+    polymerase_num_reads = Column(
+        mysqlINTEGER(10, unsigned=True), comment="The number of polymerase reads"
+    )
+    polymerase_read_length_mean = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="The mean high-quality read length of all polymerase reads",
+    )
+    polymerase_read_length_n50 = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="""Fifty percent of the trimmed read length of all polymerase
+        reads are longer than this value""",
+    )
+    insert_length_mean = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="The average subread length, considering only the longest subread from each ZMW",
+    )
+    insert_length_n50 = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="""Fifty percent of the subreads are longer than this value when considering
+        only the longest subread from each ZMW""",
+    )
+    unique_molecular_bases = Column(
+        mysqlBIGINT(20, unsigned=True), comment="The unique molecular yield in bp"
+    )
+    productive_zmws_num = Column(
+        mysqlINTEGER(10, unsigned=True), comment="Number of productive ZMWs"
+    )
+    p0_num = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="Number of empty ZMWs with no high quality read detected",
+    )
+    p1_num = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="Number of ZMWs with a high quality read detected",
+    )
+    p2_num = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="Number of other ZMWs, signal detected but no high quality read",
+    )
+    adapter_dimer_percent = Column(
+        mysqlFLOAT(5, 2, unsigned=True),
+        comment="The percentage of pre-filter ZMWs which have observed inserts of 0-10 bp",
+    )
+    short_insert_percent = Column(
+        mysqlFLOAT(5, 2, unsigned=True),
+        comment="The percentage of pre-filter ZMWs which have observed inserts of 11-100 bp",
+    )
+    hifi_read_bases = Column(
+        mysqlBIGINT(20, unsigned=True), comment="The number of HiFi bases"
+    )
+    hifi_num_reads = Column(
+        mysqlINTEGER(10, unsigned=True), comment="The number of HiFi reads"
+    )
+    hifi_read_length_mean = Column(
+        mysqlINTEGER(10, unsigned=True), comment="The mean HiFi read length"
+    )
+    hifi_read_quality_median = Column(
+        mysqlSMALLINT(5, unsigned=True), comment="The median HiFi base quality"
+    )
+    hifi_number_passes_mean = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="The mean number of passes per HiFi read",
+    )
+    hifi_low_quality_read_bases = Column(
+        mysqlBIGINT(20, unsigned=True),
+        comment="The number of HiFi bases filtered due to low quality (<Q20)",
+    )
+    hifi_low_quality_num_reads = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="The number of HiFi reads filtered due to low quality (<Q20)",
+    )
+    hifi_low_quality_read_length_mean = Column(
+        mysqlINTEGER(10, unsigned=True),
+        comment="The mean length of HiFi reads filtered due to low quality (<Q20)",
+    )
+    hifi_low_quality_read_quality_median = Column(
+        mysqlSMALLINT(5, unsigned=True),
+        comment="The median base quality of HiFi bases filtered due to low quality (<Q20)",
+    )
+
+    pac_bio_product_metrics = relationship(
+        "PacBioProductMetrics", back_populates="pac_bio_run_well_metrics"
+    )
+
+
+class PacBioProductMetrics(Base):
+    __tablename__ = "pac_bio_product_metrics"
+    __table_args__ = (
+        Index(
+            "pac_bio_metrics_product",
+            "id_pac_bio_tmp",
+            "id_pac_bio_rw_metrics_tmp",
+            unique=True,
+        ),
+        {
+            "comment": "A linking table for the pac_bio_run and pac_bio_run_well_metrics "
+            "tables with a potential for adding per-product QC data"
+        },
+    )
+
+    id_pac_bio_pr_metrics_tmp = Column(mysqlINTEGER(11), primary_key=True)
+    id_pac_bio_rw_metrics_tmp = Column(
+        ForeignKey(
+            "pac_bio_run_well_metrics.id_pac_bio_rw_metrics_tmp", ondelete="CASCADE"
+        ),
+        nullable=False,
+        index=True,
+        comment='''PacBio run well metrics id, see
+        "pac_bio_run_well_metrics.id_pac_bio_rw_metrics_tmp"''',
+    )
+    id_pac_bio_tmp = Column(
+        ForeignKey("pac_bio_run.id_pac_bio_tmp", ondelete="SET NULL"),
+        comment='PacBio run id, see "pac_bio_run.id_pac_bio_tmp"',
+    )
+    id_pac_bio_product = Column(
+        mysqlCHAR(64, charset="utf8", collation="utf8_unicode_ci"),
+        nullable=False,
+        unique=True,
+        comment="Product id",
+    )
+    qc = Column(
+        mysqlTINYINT(1),
+        index=True,
+        comment="The final QC outcome of the product as 0(failed), 1(passed) or NULL",
+    )
+
+    pac_bio_run_well_metrics = relationship(
+        "PacBioRunWellMetrics", back_populates="pac_bio_product_metrics"
+    )
+    pac_bio_run = relationship("PacBioRun", back_populates="pac_bio_product_metrics")

--- a/lang_qc/models/pacbio/experiment.py
+++ b/lang_qc/models/pacbio/experiment.py
@@ -20,8 +20,9 @@
 
 from typing import List
 
-from ml_warehouse.schema import PacBioRun
 from pydantic import BaseModel, Extra, Field
+
+from lang_qc.db.mlwh_schema import PacBioRun
 
 
 class PacBioExperiment(BaseModel):

--- a/lang_qc/models/pacbio/qc_data.py
+++ b/lang_qc/models/pacbio/qc_data.py
@@ -17,8 +17,9 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>
 
-from ml_warehouse.schema import PacBioRunWellMetrics
 from pydantic import BaseModel, Field
+
+from lang_qc.db.mlwh_schema import PacBioRunWellMetrics
 
 
 class QCDataWell(BaseModel):

--- a/lang_qc/models/pacbio/well.py
+++ b/lang_qc/models/pacbio/well.py
@@ -22,11 +22,11 @@
 from datetime import datetime
 from typing import List
 
-from ml_warehouse.schema import PacBioRunWellMetrics
 from pydantic import BaseModel, Extra, Field
 from sqlalchemy.orm import Session
 
 from lang_qc.db.helper.well import WellQc
+from lang_qc.db.mlwh_schema import PacBioRunWellMetrics
 from lang_qc.models.pacbio.experiment import PacBioExperiment
 from lang_qc.models.pacbio.qc_data import QCDataWell
 from lang_qc.models.pager import PagedResponse

--- a/misc/backfill_qc_states.py
+++ b/misc/backfill_qc_states.py
@@ -4,12 +4,12 @@ from datetime import datetime
 
 import numpy
 import pandas
-from ml_warehouse.schema import PacBioRunWellMetrics
 from sqlalchemy import select
 
 from lang_qc.db.helper.well import WellQc
 from lang_qc.db.helper.wells import WellWh
 from lang_qc.db.mlwh_connection import get_mlwh_db
+from lang_qc.db.mlwh_schema import PacBioRunWellMetrics
 from lang_qc.db.qc_connection import get_qc_db
 from lang_qc.util.auth import get_user
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -355,15 +355,6 @@ category = "dev"
 optional = false
 python-versions = "*"
 
-[[package]]
-name = "ml-warehouse"
-version = "1.1.0"
-description = "Python SQLAlchemy bindings to a warehouse housing data from multiple LIM systems."
-category = "main"
-optional = false
-python-versions = ">=3.8"
-develop = false
-
 [package.dependencies]
 cryptography = "*"
 pymysql = "*"
@@ -1253,7 +1244,6 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
-ml-warehouse = []
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ license = "GPL-3.0-or-later"
 python = "^3.10"
 fastapi = { version = "^0.78", extras = ["standard"] }
 uvicorn = { version = "^0.17", extras = ["standard"] }
-ml-warehouse = { git = "https://github.com/wtsi-npg/ml-warehouse-python.git", tag="1.3.0" }
 SQLAlchemy = { version = ">=1.4.35, < 1.4.46", extras = ["pymysql"] }
 # langqc will be incompatible with sqlalchemy 2.0. Pin version just before the deprecation warnings start
 pydantic = "^1.9.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,11 @@ import re
 import pytest
 import yaml
 from fastapi.testclient import TestClient
-from ml_warehouse.schema import Base as MlwhBase
 from sqlalchemy import create_engine, insert, text
 from sqlalchemy.orm import Session, sessionmaker
 
 from lang_qc.db.mlwh_connection import get_mlwh_db
+from lang_qc.db.mlwh_schema import Base as MlwhBase
 from lang_qc.db.qc_connection import get_qc_db
 from lang_qc.db.qc_schema import Base as QcBase
 from lang_qc.main import app

--- a/tests/data/mlwh_pb_run_92/100-Sample.yml
+++ b/tests/data/mlwh_pb_run_92/100-Sample.yml
@@ -1,2712 +1,817 @@
----
 - accession_number: SAMEA11604903
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Lamellibrachia barhami
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-02-28 15:44:36
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
-  description: ~
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: SAMEA10201627
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
+  control_type: null
+  description: null
   id_lims: SQSCP
   id_sample_lims: 7880641
   id_sample_tmp: 7816466
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-02-28 15:44:36
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: TOL_ASG12404704
-  organism: ~
-  organism_part: ~
-  phenotype: ~
+  organism: null
   public_name: wsLamBarh1
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-02-28 15:44:36
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: ~
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: TOL_ASG12404704
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: FD30882648
   taxon_id: 53613
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: 54c63f58-98ad-11ec-a764-fa163eac3af7
 - accession_number: SAMEA8576994
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Tridacna derasa
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-02-28 15:44:36
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
-  description: ~
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: SAMEA8576963
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
+  control_type: null
+  description: null
   id_lims: SQSCP
   id_sample_lims: 7880643
   id_sample_tmp: 7816468
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-02-28 15:44:36
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: TOL_ASG12404706
-  organism: ~
-  organism_part: ~
-  phenotype: ~
+  organism: null
   public_name: xbTriDera4
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-02-28 15:44:36
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: ~
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: TOL_ASG12404706
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: FD30882629
   taxon_id: 80831
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: 54cb13d4-98ad-11ec-a764-fa163eac3af7
 - accession_number: SAMEA9359482
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Closterotomus trivialis
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-02-18 16:58:34
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
-  description: ~
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: SAMEA9359418
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
+  control_type: null
+  description: null
   id_lims: SQSCP
   id_sample_lims: 7793103
   id_sample_tmp: 7729098
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-02-18 16:58:35
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: DTOL12273960
-  organism: ~
-  organism_part: ~
-  phenotype: ~
+  organism: null
   public_name: ihCloTriv1
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-02-18 16:58:35
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: ~
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: DTOL12273960
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: FD22156960/FD14790935
   taxon_id: 2026310
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: 025a2bf4-90dc-11ec-860b-fa163eac3af7
 - accession_number: ERS13494216
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: terraELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764986
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192784
   id_sample_tmp: 8128264
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:19
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764986
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:19
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Hold
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764986
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: terraELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b82fd716-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494217
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: terrabluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764987
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192785
   id_sample_tmp: 8128265
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:19
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764987
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:19
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764987
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: terrabluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b8332a6a-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494218
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: repliqELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764988
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192786
   id_sample_tmp: 8128266
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:18
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764988
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:18
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764988
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: repliqELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b8356582-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494219
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: repliqbluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764989
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192787
   id_sample_tmp: 8128267
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:18
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764989
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:18
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764989
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: repliqbluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b83791c2-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494220
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: longampELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764990
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192788
   id_sample_tmp: 8128268
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:17
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764990
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:17
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764990
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: longampELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b839adfe-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494221
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: longamp bluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764991
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192789
   id_sample_tmp: 8128269
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:17
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764991
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:17
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Hold
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764991
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: longamp bluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b83bae7e-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494222
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: Q5ELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764992
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192790
   id_sample_tmp: 8128270
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:15
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764992
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:15
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764992
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: Q5ELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b83dc786-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494225
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: Q5 bluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764993
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192791
   id_sample_tmp: 8128271
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:15
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764993
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:15
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764993
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: Q5 bluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b83ff286-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494223
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: WmELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764994
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192792
   id_sample_tmp: 8128272
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:16
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764994
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:16
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764994
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: WmELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b8426cd2-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494224
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: Wmbluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764995
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192793
   id_sample_tmp: 8128273
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:16
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764995
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:16
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764995
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: Wmbluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b8449b74-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494228
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: WmELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764996
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192794
   id_sample_tmp: 8128274
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:16
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764996
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:16
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764996
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: WmELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b846f84c-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494226
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: Wmbluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764997
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192795
   id_sample_tmp: 8128275
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:16
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764997
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:16
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764997
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: Wmbluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b84917ee-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494227
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: promegaELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764998
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192796
   id_sample_tmp: 8128276
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:17
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764998
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:17
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764998
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: promegaELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b84b3a4c-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494233
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: promegabluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412764999
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192797
   id_sample_tmp: 8128277
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:17
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412764999
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:17
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412764999
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: promegabluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b84d5ae8-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494230
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: superfiELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765000
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192798
   id_sample_tmp: 8128278
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:18
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765000
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:18
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765000
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: superfiELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b84f7562-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494229
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: superfibluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765001
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192799
   id_sample_tmp: 8128279
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:18
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765001
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:18
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765001
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: superfibluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b852053e-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494231
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: kapaELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765002
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192800
   id_sample_tmp: 8128280
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:16
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765002
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:16
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765002
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: kapaELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b8543728-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494232
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: kapabluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765003
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192801
   id_sample_tmp: 8128281
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:16
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765003
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:16
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765003
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: kapabluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b85709c6-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494256
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: universeELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765004
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192802
   id_sample_tmp: 8128282
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:19
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765004
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:19
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765004
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: universeELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b859c756-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494246
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: universebluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765005
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192803
   id_sample_tmp: 8128283
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:19
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765005
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:19
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765005
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: universebluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b85c8c16-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494235
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: LaTaqELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765006
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192804
   id_sample_tmp: 8128284
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:13
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765006
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:13
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765006
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: LaTaqELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b85f7b10-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494234
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: LaTaq bluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765007
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192805
   id_sample_tmp: 8128285
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:13
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765007
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:13
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765007
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: LaTaq bluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b8622a90-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494236
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: ExpandELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765008
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192806
   id_sample_tmp: 8128286
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:13
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765008
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:13
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765008
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: ExpandELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b8644bc2-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494257
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: Expandbluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765009
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192807
   id_sample_tmp: 8128287
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:13
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765009
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:13
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765009
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: Expandbluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b86666d2-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494237
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: verifiELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765010
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192808
   id_sample_tmp: 8128288
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:20
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765010
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:20
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Hold
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765010
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: verifiELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b868948e-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494238
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: verifibluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765011
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192809
   id_sample_tmp: 8128289
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:20
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765011
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:20
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765011
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: verifibluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b86aaf4e-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494239
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: PfuultraIIELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765012
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192810
   id_sample_tmp: 8128290
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:14
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765012
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:14
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765012
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: PfuultraIIELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b86cc5ae-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494240
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: PfuultraIIbluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765013
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192811
   id_sample_tmp: 8128291
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:14
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765013
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:14
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765013
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: PfuultraIIbluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b86eca5c-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494243
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: PrimestarMAXELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765014
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192812
   id_sample_tmp: 8128292
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:15
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765014
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:15
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765014
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: PrimestarMAXELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b870bf6a-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494244
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: PrimestarMAXbluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765015
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192813
   id_sample_tmp: 8128293
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:15
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765015
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:15
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765015
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: PrimestarMAXbluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b872baae-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494245
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: PrimestarGXLELF15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765016
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192814
   id_sample_tmp: 8128294
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:14
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765016
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:14
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765016
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: PrimestarGXLELF15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b874bba6-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494247
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: PrimestarGXLbluepippin15
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765017
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192815
   id_sample_tmp: 8128295
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:15
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765017
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:15
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Hold
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765017
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: PrimestarGXLbluepippin15
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b876abd2-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494248
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:57
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: TerraF1_12
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765018
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192816
   id_sample_tmp: 8128296
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:16
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765018
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:16
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Hold
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765018
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: TerraF1_12
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b878acde-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494249
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:58
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: TerraB_12
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765019
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192817
   id_sample_tmp: 8128297
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:15
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765019
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:15
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765019
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: TerraB_12
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b87aa872-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494250
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:58
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: repliQaF1_12
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765020
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192818
   id_sample_tmp: 8128298
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:18
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765020
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:18
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Hold
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765020
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: repliQaF1_12
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b87cc1de-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494251
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:58
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: repliQaB_12
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765021
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192819
   id_sample_tmp: 8128299
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:17
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765021
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:17
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765021
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: repliQaB_12
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b87ed6a4-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494252
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:58
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: LongAmpF1_12
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765022
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192820
   id_sample_tmp: 8128300
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:14
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765022
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:14
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765022
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: LongAmpF1_12
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b880f056-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494253
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:58
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: LongAmpB_12
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765023
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192821
   id_sample_tmp: 8128301
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:14
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765023
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:14
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765023
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: LongAmpB_12
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b883178c-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494254
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:58
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: promegaF2_12
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765024
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192822
   id_sample_tmp: 8128302
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:17
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765024
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:17
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765024
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: promegaF2_12
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b8853ff8-b3f6-11ec-9caa-fa163eac3af7
 - accession_number: ERS13494255
-  age: ~
-  cell_type: ~
-  cohort: ~
   common_name: Saccharomyces cerevisiae
-  compound: ~
-  concentration_determined_by: ~
   consent_withdrawn: 0
   control: 0
-  control_type: ~
-  country_of_origin: ~
-  created: 2022-04-04 09:07:58
-  customer_measured_concentration: ~
-  customer_measured_volume: ~
-  date_of_consent_withdrawn: ~
-  date_of_sample_collection: ~
-  date_of_sample_extraction: ~
-  deleted_at: ~
+  control_type: null
   description: promegaB_12
-  developmental_stage: ~
-  disease: ~
-  disease_state: ~
-  dna_source: ~
-  donor_id: MQ201412765025
-  dose: ~
-  ethnicity: ~
-  extraction_method: ~
-  father: ~
-  gc_content: ~
-  gender: ~
-  genotype: ~
-  geographical_region: ~
-  growth_condition: ~
   id_lims: SQSCP
   id_sample_lims: 8192823
   id_sample_tmp: 8128303
-  immunoprecipitate: ~
-  is_resubmitted: ~
-  last_updated: 2022-09-27 13:00:17
-  marked_as_consent_withdrawn_by: ~
-  mother: ~
   name: MQ201412765025
-  organism: ~
-  organism_part: ~
-  phenotype: ~
-  public_name: ~
-  purification_method: ~
-  purified: ~
-  recorded_at: 2022-09-27 13:00:17
-  reference_genome: ~
-  replicate: ~
-  sample_type: ~
-  sample_visibility: Public
+  organism: null
+  public_name: null
+  reference_genome: null
+  sample_type: null
   sanger_sample_id: MQ201412765025
-  sibling: ~
-  storage_conditions: ~
-  strain: ~
-  subject: ~
+  strain: null
   supplier_name: promegaB_12
   taxon_id: 4932
-  time_point: ~
-  treatment: ~
   uuid_sample_lims: b887566c-b3f6-11ec-9caa-fa163eac3af7
-
-

--- a/tests/data/mlwh_pb_run_92/100-Study.yml
+++ b/tests/data/mlwh_pb_run_92/100-Study.yml
@@ -1,109 +1,43 @@
----
-- abbreviation: TOL_ASG
-  abstract: 'Sequencing and assembly.'
-  accession_number: ERP129860
+- accession_number: ERP129860
   aligned: 1
-  array_express_accession_number: ~
   contains_human_dna: 0
   contaminated_human_dna: 0
-  created: 2021-04-21 15:23:40
-  data_access_group: ~
-  data_deletion_period: ~
-  data_destination: ~
-  data_release_delay_period: ~
-  data_release_delay_reason: ~
-  data_release_sort_of_study: genomic sequencing
-  data_release_strategy: not applicable
-  faculty_sponsor: Mark
-  hmdmc_number: ~
   id_lims: SQSCP
   id_study_lims: 6457
   id_study_tmp: 6287
-  last_updated: 2022-12-08 16:43:35
-  name: 'Tree of Life - ASG'
-  prelim_id: ~
-  recorded_at: 2022-12-08 16:43:35
+  name: Tree of Life - ASG
   reference_genome: ' '
   remove_x_and_autosomes: 0
-  s3_email_list: ~
   separate_y_chromosome_data: 0
-  state: active
-  study_title: 'Tree of Life - ASG'
-  study_type: Whole Genome Sequencing
+  study_title: Tree of Life - ASG
   study_visibility: Public
   uuid_study_lims: 8d58238e-a2b5-11eb-84d2-fa163eac3af7
-- abbreviation: DTOL
-  abstract: 'Sequencing and some assembly.'
-  accession_number: ERP116890
+- accession_number: ERP116890
   aligned: 1
-  array_express_accession_number: ~
   contains_human_dna: 0
   contaminated_human_dna: 0
-  created: 2019-07-22 13:15:42
-  data_access_group: ~
-  data_deletion_period: ~
-  data_destination: ~
-  data_release_delay_period: ~
-  data_release_delay_reason: ~
-  data_release_sort_of_study: genomic sequencing
-  data_release_strategy: not applicable
-  data_release_timing: never
-  deleted_at: ~
-  faculty_sponsor: Mark
-  hmdmc_number: ~
   id_lims: SQSCP
   id_study_lims: 5901
   id_study_tmp: 5735
-  last_updated: 2022-08-05 10:17:50
   name: DTOL_Darwin Tree of Life
-  prelim_id: ~
-  recorded_at: 2022-08-05 10:17:50
   reference_genome: ' '
   remove_x_and_autosomes: 0
-  s3_email_list: ~
   separate_y_chromosome_data: 0
-  state: active
   study_title: Darwin Tree of Life
-  study_type: Whole Genome Sequencing
   study_visibility: Public
   uuid_study_lims: cf04ea86-ac82-11e9-8998-68b599768938
-- abbreviation: Alt_Enz22mic
-  abstract: 'Sequencing and no assembly.'
-  accession_number: ERP141224
+- accession_number: ERP141224
   aligned: 1
-  array_express_accession_number: ~
   contains_human_dna: 0
   contaminated_human_dna: 0
-  created: 2022-09-15 14:11:00
-  data_access_group: ~
-  data_deletion_period: ~
-  data_destination: ~
-  data_release_delay_period: ~
-  data_release_delay_reason: ~
-  data_release_sort_of_study: genomic sequencing
-  data_release_strategy: open
-  data_release_timing: immediate
-  deleted_at: ~
-  description: Study for release prior to publication of selected datasets from MQ R&D 2014 stud
-  ega_dac_accession_number: ~
-  ega_policy_accession_number: ~
-  ena_project_id: ~
-  ethically_approved: ~
-  faculty_sponsor: Harold Swerdlow
-  hmdmc_number: ~
+  description: Study for release prior to publication of selected datasets
   id_lims: SQSCP
   id_study_lims: 7069
   id_study_tmp: 6942
-  last_updated: 2022-09-26 14:36:04
   name: Alternative Enzymes 2022 microbial genomes
-  prelim_id: ~
-  recorded_at: 2022-09-26 14:36:04
   reference_genome: Clostridium_difficile (Strain_630)
   remove_x_and_autosomes: 0
-  s3_email_list: ~
   separate_y_chromosome_data: 0
-  state: active
   study_title: Alternative Enzymes 2022 microbial genomes
-  study_type: Whole Genome Sequencing
   study_visibility: Public
   uuid_study_lims: 39ba6ae6-3500-11ed-b3f3-fa163eac3af7

--- a/tests/endpoints/test_single_well_qc_details.py
+++ b/tests/endpoints/test_single_well_qc_details.py
@@ -9,7 +9,7 @@ def test_get_well_info(
 ):
 
     insert_from_yaml(
-        mlwhdb_test_session, "tests/data/mlwh_pb_run_92", "ml_warehouse.schema"
+        mlwhdb_test_session, "tests/data/mlwh_pb_run_92", "lang_qc.db.mlwh_schema"
     )
 
     response = test_client.get("/pacbio/run/MARATHON/well/A0")

--- a/tests/fixtures/inbox_data.py
+++ b/tests/fixtures/inbox_data.py
@@ -1,15 +1,15 @@
 from datetime import datetime, timedelta
 
 import pytest
-from ml_warehouse.schema import (
+from npg_id_generation.pac_bio import PacBioEntity
+
+from lang_qc.db.mlwh_schema import (
     PacBioProductMetrics,
     PacBioRun,
     PacBioRunWellMetrics,
     Sample,
     Study,
 )
-from npg_id_generation.pac_bio import PacBioEntity
-
 from lang_qc.db.qc_schema import (
     ProductLayout,
     QcState,

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -1,12 +1,12 @@
-from ml_warehouse.schema import (
+from sqlalchemy import delete, text
+
+from lang_qc.db.mlwh_schema import (
     PacBioProductMetrics,
     PacBioRun,
     PacBioRunWellMetrics,
     Sample,
     Study,
 )
-from sqlalchemy import delete, text
-
 from lang_qc.db.qc_schema import (
     ProductLayout,
     QcState,

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -1,4 +1,4 @@
-from sqlalchemy import delete, text
+from sqlalchemy import delete
 
 from lang_qc.db.mlwh_schema import (
     PacBioProductMetrics,

--- a/tests/fixtures/well_data.py
+++ b/tests/fixtures/well_data.py
@@ -1,11 +1,11 @@
 from datetime import date, datetime, timedelta
 
 import pytest
-from ml_warehouse.schema import PacBioRunWellMetrics
 from npg_id_generation.pac_bio import PacBioEntity
 from sqlalchemy import insert, select
 
 from lang_qc.db.helper.well import WellQc
+from lang_qc.db.mlwh_schema import PacBioRunWellMetrics
 from lang_qc.db.qc_schema import QcStateDict, QcType, SeqPlatform, SubProductAttr, User
 
 QC_TYPES = [

--- a/tests/test_pac_bio_experiment.py
+++ b/tests/test_pac_bio_experiment.py
@@ -1,7 +1,7 @@
 import pytest
-from ml_warehouse.schema import PacBioRun
 from sqlalchemy import select
 
+from lang_qc.db.mlwh_schema import PacBioRun
 from lang_qc.models.pacbio.experiment import PacBioExperiment
 from tests.conftest import insert_from_yaml
 
@@ -12,7 +12,7 @@ def test_creating_experiment_object(mlwhdb_test_session):
     # Four wells, D1 has 40 samples, the rest have one sample each.
 
     insert_from_yaml(
-        mlwhdb_test_session, "tests/data/mlwh_pb_run_92", "ml_warehouse.schema"
+        mlwhdb_test_session, "tests/data/mlwh_pb_run_92", "lang_qc.db.mlwh_schema"
     )
 
     query = (

--- a/tests/test_pac_well_full.py
+++ b/tests/test_pac_well_full.py
@@ -1,6 +1,6 @@
-from ml_warehouse.schema import PacBioRunWellMetrics
 from sqlalchemy import select
 
+from lang_qc.db.mlwh_schema import PacBioRunWellMetrics
 from lang_qc.models.pacbio.well import PacBioWellFull
 from tests.conftest import compare_dates, insert_from_yaml
 from tests.fixtures.well_data import load_data4well_retrieval, load_dicts_and_users
@@ -11,7 +11,7 @@ def test_creating_experiment_object(
 ):
 
     insert_from_yaml(
-        mlwhdb_test_session, "tests/data/mlwh_pb_run_92", "ml_warehouse.schema"
+        mlwhdb_test_session, "tests/data/mlwh_pb_run_92", "lang_qc.db.mlwh_schema"
     )
 
     # Full mlwh data, no data in the lang_qc database.

--- a/tests/test_wh_data_retrieval_pb.py
+++ b/tests/test_wh_data_retrieval_pb.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 
 import pytest
-from ml_warehouse.schema import PacBioRunWellMetrics
 from sqlalchemy import select
 
 from lang_qc.db.helper.wells import EmptyListOfRunNamesError, WellWh
+from lang_qc.db.mlwh_schema import PacBioRunWellMetrics
 from tests.fixtures.well_data import load_data4well_retrieval, load_dicts_and_users
 
 


### PR DESCRIPTION
Copied a few classes we need from the external
ml_warehouse package to lang_qc.db.mlwh_schema.
Reduced the number of imports to the types that
are actually needed. Reduced the number of mapped
columns for the study and sample tables to columns we are or might be using.