### PR TITLE
Use many-to-many relationship in sqlalchemy.

### DIFF
--- a/lang_qc/db/helper/well.py
+++ b/lang_qc/db/helper/well.py
@@ -35,7 +35,6 @@ from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 
 from lang_qc.db.qc_schema import (
-    ProductLayout,
     QcState,
     QcStateDict,
     QcStateHist,
@@ -385,16 +384,14 @@ class WellQc(QcDictDB):
         well_product = SeqProduct(
             id_product=product_id,
             id_seq_platform=id_seq_platform,
-            product_layout=[
-                ProductLayout(
-                    sub_product=SubProduct(
-                        id_attr_one=product_attr_id_rn,
-                        value_attr_one=self.run_name,
-                        id_attr_two=product_attr_id_wl,
-                        value_attr_two=self.well_label,
-                        properties=product_json,
-                        properties_digest=product_id,
-                    )
+            sub_products=[
+                SubProduct(
+                    id_attr_one=product_attr_id_rn,
+                    value_attr_one=self.run_name,
+                    id_attr_two=product_attr_id_wl,
+                    value_attr_two=self.well_label,
+                    properties=product_json,
+                    properties_digest=product_id,
                 )
             ],
         )

--- a/lang_qc/db/helper/wells.py
+++ b/lang_qc/db/helper/wells.py
@@ -293,7 +293,7 @@ class PacBioPagedWellsFactory(WellWh, PagedResponse):
         # They'd better be correct there!
         wells = []
         for qc_state in self._retrieve_qc_states(qc_flow_status):
-            sub_product = qc_state.seq_product.product_layout[0].sub_product
+            sub_product = qc_state.seq_product.sub_products[0]
             # TODO: consider adding from_orm method to PacBioWell
             wells.append(
                 PacBioWell(

--- a/lang_qc/db/qc_schema.py
+++ b/lang_qc/db/qc_schema.py
@@ -37,83 +37,107 @@ Base = declarative_base()
 
 
 class QcStateDict(Base):
-    __tablename__ = 'qc_state_dict'
+    __tablename__ = "qc_state_dict"
 
     id_qc_state_dict = Column(INTEGER, primary_key=True)
     state = Column(String(255), nullable=False, unique=True)
     outcome = Column(TINYINT)
 
-    qc_state = relationship('QcState', back_populates='qc_state_dict')
-    qc_state_hist = relationship('QcStateHist', back_populates='qc_state_dict')
+    qc_state = relationship("QcState", back_populates="qc_state_dict")
+    qc_state_hist = relationship("QcStateHist", back_populates="qc_state_dict")
 
 
 class QcType(Base):
-    __tablename__ = 'qc_type'
+    __tablename__ = "qc_type"
 
     id_qc_type = Column(INTEGER, primary_key=True)
     qc_type = Column(String(10), nullable=False, unique=True)
     description = Column(String(255), nullable=False)
 
-    qc_state = relationship('QcState', back_populates='qc_type')
-    qc_state_hist = relationship('QcStateHist', back_populates='qc_type')
+    qc_state = relationship("QcState", back_populates="qc_type")
+    qc_state_hist = relationship("QcStateHist", back_populates="qc_type")
 
 
 class SeqPlatform(Base):
-    __tablename__ = 'seq_platform'
+    __tablename__ = "seq_platform"
 
     id_seq_platform = Column(INTEGER, primary_key=True)
     name = Column(String(10), nullable=False, unique=True)
     description = Column(String(255), nullable=False)
     iscurrent = Column(TINYINT(1), nullable=False, server_default=text("'1'"))
 
-    seq_product = relationship('SeqProduct', back_populates='seq_platform')
+    seq_product = relationship("SeqProduct", back_populates="seq_platform")
 
 
 class SubProductAttr(Base):
-    __tablename__ = 'sub_product_attr'
+    __tablename__ = "sub_product_attr"
 
     id_attr = Column(INTEGER, primary_key=True)
     attr_name = Column(String(20), nullable=False, unique=True)
     description = Column(String(255), nullable=False)
 
-    sub_product = relationship('SubProduct', foreign_keys='[SubProduct.id_attr_one]', back_populates='sub_product_attr')
-    sub_product_ = relationship('SubProduct', foreign_keys='[SubProduct.id_attr_two]', back_populates='sub_product_attr_')
+    sub_product = relationship(
+        "SubProduct",
+        foreign_keys="[SubProduct.id_attr_one]",
+        back_populates="sub_product_attr",
+    )
+    sub_product_ = relationship(
+        "SubProduct",
+        foreign_keys="[SubProduct.id_attr_two]",
+        back_populates="sub_product_attr_",
+    )
 
 
 class User(Base):
-    __tablename__ = 'user'
+    __tablename__ = "user"
 
     id_user = Column(INTEGER, primary_key=True)
     username = Column(String(255), nullable=False, unique=True)
     iscurrent = Column(TINYINT(1), nullable=False, server_default=text("'1'"))
-    date_created = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'), comment='Datetime the user record was created')
-    date_updated = Column(DateTime, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'), comment='Datetime the user record was created or changed')
+    date_created = Column(
+        DateTime,
+        server_default=text("CURRENT_TIMESTAMP"),
+        comment="Datetime the user record was created",
+    )
+    date_updated = Column(
+        DateTime,
+        server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+        comment="Datetime the user record was created or changed",
+    )
 
-    annotation = relationship('Annotation', back_populates='user')
-    qc_state = relationship('QcState', back_populates='user')
-    qc_state_hist = relationship('QcStateHist', back_populates='user')
+    annotation = relationship("Annotation", back_populates="user")
+    qc_state = relationship("QcState", back_populates="user")
+    qc_state_hist = relationship("QcStateHist", back_populates="user")
 
 
 class Annotation(Base):
-    __tablename__ = 'annotation'
+    __tablename__ = "annotation"
     __table_args__ = (
-        ForeignKeyConstraint(['id_user'], ['user.id_user'], name='fk_annotation_user'),
+        ForeignKeyConstraint(["id_user"], ["user.id_user"], name="fk_annotation_user"),
     )
 
     id_annotation = Column(BIGINT, primary_key=True)
     id_user = Column(INTEGER, nullable=False, index=True)
     comment = Column(Text, nullable=False)
-    date_created = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'), comment='Datetime this record was created')
+    date_created = Column(
+        DateTime,
+        server_default=text("CURRENT_TIMESTAMP"),
+        comment="Datetime this record was created",
+    )
     qc_specific = Column(TINYINT(1), server_default=text("'0'"))
 
-    user = relationship('User', back_populates='annotation')
-    product_annotation = relationship('ProductAnnotation', back_populates='annotation')
+    user = relationship("User", back_populates="annotation")
+    product_annotation = relationship("ProductAnnotation", back_populates="annotation")
 
 
 class SeqProduct(Base):
-    __tablename__ = 'seq_product'
+    __tablename__ = "seq_product"
     __table_args__ = (
-        ForeignKeyConstraint(['id_seq_platform'], ['seq_platform.id_seq_platform'], name='fk_subproduct_seq_pl'),
+        ForeignKeyConstraint(
+            ["id_seq_platform"],
+            ["seq_platform.id_seq_platform"],
+            name="fk_subproduct_seq_pl",
+        ),
     )
 
     id_seq_product = Column(BIGINT, primary_key=True)
@@ -121,18 +145,24 @@ class SeqProduct(Base):
     id_seq_platform = Column(INTEGER, nullable=False, index=True)
     has_seq_data = Column(TINYINT(1), server_default=text("'1'"))
 
-    seq_platform = relationship('SeqPlatform', back_populates='seq_product')
-    product_annotation = relationship('ProductAnnotation', back_populates='seq_product')
-    product_layout = relationship('ProductLayout', back_populates='seq_product')
-    qc_state = relationship('QcState', back_populates='seq_product')
-    qc_state_hist = relationship('QcStateHist', back_populates='seq_product')
+    seq_platform = relationship("SeqPlatform", back_populates="seq_product")
+    product_annotation = relationship("ProductAnnotation", back_populates="seq_product")
+    sub_products = relationship(
+        "SubProduct", secondary="product_layout", back_populates="seq_products"
+    )
+    qc_state = relationship("QcState", back_populates="seq_product")
+    qc_state_hist = relationship("QcStateHist", back_populates="seq_product")
 
 
 class SubProduct(Base):
-    __tablename__ = 'sub_product'
+    __tablename__ = "sub_product"
     __table_args__ = (
-        ForeignKeyConstraint(['id_attr_one'], ['sub_product_attr.id_attr'], name='fk_subproduct_attr1'),
-        ForeignKeyConstraint(['id_attr_two'], ['sub_product_attr.id_attr'], name='fk_subproduct_attr2')
+        ForeignKeyConstraint(
+            ["id_attr_one"], ["sub_product_attr.id_attr"], name="fk_subproduct_attr1"
+        ),
+        ForeignKeyConstraint(
+            ["id_attr_two"], ["sub_product_attr.id_attr"], name="fk_subproduct_attr2"
+        ),
     )
 
     id_sub_product = Column(BIGINT, primary_key=True)
@@ -144,50 +174,77 @@ class SubProduct(Base):
     properties_digest = Column(CHAR(64), nullable=False, unique=True)
     tags = Column(String(255), index=True)
 
-    sub_product_attr = relationship('SubProductAttr', foreign_keys=[id_attr_one], back_populates='sub_product')
-    sub_product_attr_ = relationship('SubProductAttr', foreign_keys=[id_attr_two], back_populates='sub_product_')
-    product_layout = relationship('ProductLayout', back_populates='sub_product')
+    sub_product_attr = relationship(
+        "SubProductAttr", foreign_keys=[id_attr_one], back_populates="sub_product"
+    )
+    sub_product_attr_ = relationship(
+        "SubProductAttr", foreign_keys=[id_attr_two], back_populates="sub_product_"
+    )
+    seq_products = relationship(
+        "SeqProduct", secondary="product_layout", back_populates="sub_products"
+    )
 
 
 class ProductAnnotation(Base):
-    __tablename__ = 'product_annotation'
+    __tablename__ = "product_annotation"
     __table_args__ = (
-        ForeignKeyConstraint(['id_annotation'], ['annotation.id_annotation'], name='fk_pr_annotation_annotation'),
-        ForeignKeyConstraint(['id_seq_product'], ['seq_product.id_seq_product'], name='fk_pr_annotation_product')
+        ForeignKeyConstraint(
+            ["id_annotation"],
+            ["annotation.id_annotation"],
+            name="fk_pr_annotation_annotation",
+        ),
+        ForeignKeyConstraint(
+            ["id_seq_product"],
+            ["seq_product.id_seq_product"],
+            name="fk_pr_annotation_product",
+        ),
     )
 
     id_product_annotation = Column(BIGINT, primary_key=True)
     id_annotation = Column(BIGINT, nullable=False, index=True)
     id_seq_product = Column(BIGINT, nullable=False, index=True)
 
-    annotation = relationship('Annotation', back_populates='product_annotation')
-    seq_product = relationship('SeqProduct', back_populates='product_annotation')
+    annotation = relationship("Annotation", back_populates="product_annotation")
+    seq_product = relationship("SeqProduct", back_populates="product_annotation")
 
 
 class ProductLayout(Base):
-    __tablename__ = 'product_layout'
+    __tablename__ = "product_layout"
     __table_args__ = (
-        ForeignKeyConstraint(['id_seq_product'], ['seq_product.id_seq_product'], name='fk_product_layout_seqpr'),
-        ForeignKeyConstraint(['id_sub_product'], ['sub_product.id_sub_product'], name='fk_product_layout_subpr'),
-        Index('unique_product_layout', 'id_seq_product', 'id_sub_product', unique=True)
+        ForeignKeyConstraint(
+            ["id_seq_product"],
+            ["seq_product.id_seq_product"],
+            name="fk_product_layout_seqpr",
+        ),
+        ForeignKeyConstraint(
+            ["id_sub_product"],
+            ["sub_product.id_sub_product"],
+            name="fk_product_layout_subpr",
+        ),
+        Index("unique_product_layout", "id_seq_product", "id_sub_product", unique=True),
     )
 
     id_product_layout = Column(BIGINT, primary_key=True)
     id_seq_product = Column(BIGINT, nullable=False)
     id_sub_product = Column(BIGINT, nullable=False, index=True)
 
-    seq_product = relationship('SeqProduct', back_populates='product_layout')
-    sub_product = relationship('SubProduct', back_populates='product_layout')
-
 
 class QcState(Base):
-    __tablename__ = 'qc_state'
+    __tablename__ = "qc_state"
     __table_args__ = (
-        ForeignKeyConstraint(['id_qc_state_dict'], ['qc_state_dict.id_qc_state_dict'], name='fk_qc_state_state'),
-        ForeignKeyConstraint(['id_qc_type'], ['qc_type.id_qc_type'], name='fk_qc_type'),
-        ForeignKeyConstraint(['id_seq_product'], ['seq_product.id_seq_product'], name='fk_qc_state_product'),
-        ForeignKeyConstraint(['id_user'], ['user.id_user'], name='fk_qc_state_user'),
-        Index('unique_qc_state', 'id_seq_product', 'id_qc_type', unique=True)
+        ForeignKeyConstraint(
+            ["id_qc_state_dict"],
+            ["qc_state_dict.id_qc_state_dict"],
+            name="fk_qc_state_state",
+        ),
+        ForeignKeyConstraint(["id_qc_type"], ["qc_type.id_qc_type"], name="fk_qc_type"),
+        ForeignKeyConstraint(
+            ["id_seq_product"],
+            ["seq_product.id_seq_product"],
+            name="fk_qc_state_product",
+        ),
+        ForeignKeyConstraint(["id_user"], ["user.id_user"], name="fk_qc_state_user"),
+        Index("unique_qc_state", "id_seq_product", "id_qc_type", unique=True),
     )
 
     id_qc_state = Column(BIGINT, primary_key=True)
@@ -197,22 +254,40 @@ class QcState(Base):
     id_qc_type = Column(INTEGER, nullable=False, index=True)
     created_by = Column(String(20), nullable=False)
     is_preliminary = Column(TINYINT(1), server_default=text("'1'"))
-    date_created = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'), comment='Datetime this record was created')
-    date_updated = Column(DateTime, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'), comment='Datetime this record was created or changed')
+    date_created = Column(
+        DateTime,
+        server_default=text("CURRENT_TIMESTAMP"),
+        comment="Datetime this record was created",
+    )
+    date_updated = Column(
+        DateTime,
+        server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+        comment="Datetime this record was created or changed",
+    )
 
-    qc_state_dict = relationship('QcStateDict', back_populates='qc_state')
-    qc_type = relationship('QcType', back_populates='qc_state')
-    seq_product = relationship('SeqProduct', back_populates='qc_state')
-    user = relationship('User', back_populates='qc_state')
+    qc_state_dict = relationship("QcStateDict", back_populates="qc_state")
+    qc_type = relationship("QcType", back_populates="qc_state")
+    seq_product = relationship("SeqProduct", back_populates="qc_state")
+    user = relationship("User", back_populates="qc_state", uselist=False)
 
 
 class QcStateHist(Base):
-    __tablename__ = 'qc_state_hist'
+    __tablename__ = "qc_state_hist"
     __table_args__ = (
-        ForeignKeyConstraint(['id_qc_state_dict'], ['qc_state_dict.id_qc_state_dict'], name='fk_qc_stateh_state'),
-        ForeignKeyConstraint(['id_qc_type'], ['qc_type.id_qc_type'], name='fk_qc_stateh_type'),
-        ForeignKeyConstraint(['id_seq_product'], ['seq_product.id_seq_product'], name='fk_qc_stateh_product'),
-        ForeignKeyConstraint(['id_user'], ['user.id_user'], name='fk_qc_stateh_user')
+        ForeignKeyConstraint(
+            ["id_qc_state_dict"],
+            ["qc_state_dict.id_qc_state_dict"],
+            name="fk_qc_stateh_state",
+        ),
+        ForeignKeyConstraint(
+            ["id_qc_type"], ["qc_type.id_qc_type"], name="fk_qc_stateh_type"
+        ),
+        ForeignKeyConstraint(
+            ["id_seq_product"],
+            ["seq_product.id_seq_product"],
+            name="fk_qc_stateh_product",
+        ),
+        ForeignKeyConstraint(["id_user"], ["user.id_user"], name="fk_qc_stateh_user"),
     )
 
     id_qc_state_hist = Column(BIGINT, primary_key=True)
@@ -221,11 +296,17 @@ class QcStateHist(Base):
     id_qc_state_dict = Column(INTEGER, nullable=False, index=True)
     id_qc_type = Column(INTEGER, nullable=False, index=True)
     created_by = Column(String(20), nullable=False)
-    date_created = Column(DateTime, nullable=False, comment='Datetime the original record was created')
-    date_updated = Column(DateTime, nullable=False, comment='Datetime the original record was created or changed')
+    date_created = Column(
+        DateTime, nullable=False, comment="Datetime the original record was created"
+    )
+    date_updated = Column(
+        DateTime,
+        nullable=False,
+        comment="Datetime the original record was created or changed",
+    )
     is_preliminary = Column(TINYINT(1), server_default=text("'1'"))
 
-    qc_state_dict = relationship('QcStateDict', back_populates='qc_state_hist')
-    qc_type = relationship('QcType', back_populates='qc_state_hist')
-    seq_product = relationship('SeqProduct', back_populates='qc_state_hist')
-    user = relationship('User', back_populates='qc_state_hist')
+    qc_state_dict = relationship("QcStateDict", back_populates="qc_state_hist")
+    qc_type = relationship("QcType", back_populates="qc_state_hist")
+    seq_product = relationship("SeqProduct", back_populates="qc_state_hist")
+    user = relationship("User", back_populates="qc_state_hist")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,5 @@ pandas = "1.5.2"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.black]
-extend-exclude = "lang_qc/db/qc_schema.py"
-
 [tool.isort]
 profile = "black"

--- a/tests/fixtures/inbox_data.py
+++ b/tests/fixtures/inbox_data.py
@@ -11,7 +11,6 @@ from lang_qc.db.mlwh_schema import (
     Study,
 )
 from lang_qc.db.qc_schema import (
-    ProductLayout,
     QcState,
     QcStateDict,
     QcType,
@@ -181,17 +180,15 @@ def test_data_factory(mlwhdb_test_session, qcdb_test_session):
                         seq_product=SeqProduct(
                             id_product=id,
                             seq_platform=seq_platform,
-                            product_layout=[
-                                ProductLayout(
-                                    sub_product=SubProduct(
-                                        sub_product_attr=run_name_attr,
-                                        sub_product_attr_=well_label_attr,
-                                        value_attr_one=run_name,
-                                        value_attr_two=well_label,
-                                        properties=json,
-                                        properties_digest=id,
-                                    ),
-                                )
+                            sub_products=[
+                                SubProduct(
+                                    sub_product_attr=run_name_attr,
+                                    sub_product_attr_=well_label_attr,
+                                    value_attr_one=run_name,
+                                    value_attr_two=well_label,
+                                    properties=json,
+                                    properties_digest=id,
+                                ),
                             ],
                         ),
                         user=user,

--- a/tests/test_qc_state_maintenance.py
+++ b/tests/test_qc_state_maintenance.py
@@ -74,8 +74,8 @@ def test_well_state_helper(qcdb_test_session, load_dicts_and_users):
 
     assert state_obj.seq_product.seq_platform.name == "PacBio"
     assert state_obj.seq_product.id_product == id
-    assert len(state_obj.seq_product.product_layout) == 1
-    sub_product = state_obj.seq_product.product_layout[0].sub_product
+    assert len(state_obj.seq_product.sub_products) == 1
+    sub_product = state_obj.seq_product.sub_products[0]
     assert sub_product.properties == json
     assert sub_product.properties_digest == id
     assert sub_product.value_attr_one == "TRACTION-RUN-450"


### PR DESCRIPTION
No need to reference the linker table anywhere. See `sub_products` relationship. Schema file reformatted with black now we're not expecting to regenerate it.