### PR TITLE
Claim and update QC by product ID

### DIFF
--- a/lang_qc/db/helper/wells.py
+++ b/lang_qc/db/helper/wells.py
@@ -68,21 +68,6 @@ class WellWh(BaseModel):
         arbitrary_types_allowed = True
         allow_population_by_field_name = True
 
-    def get_well(self, run_name: str, well_label: str) -> PacBioRunWellMetrics | None:
-        """
-        Returns a well row record from the well metrics table or
-        None if the record does not exist.
-        """
-
-        return self.session.execute(
-            select(PacBioRunWellMetrics).where(
-                and_(
-                    PacBioRunWellMetrics.pac_bio_run_name == run_name,
-                    PacBioRunWellMetrics.well_label == well_label,
-                )
-            )
-        ).scalar_one_or_none()
-
     def get_mlwh_well_by_product_id(
         self, id_product: str
     ) -> PacBioRunWellMetrics | None:
@@ -96,14 +81,6 @@ class WellWh(BaseModel):
                 PacBioRunWellMetrics.id_pac_bio_product == id_product,
             )
         ).scalar_one_or_none()
-
-    def well_exists(self, run_name: str, well_label: str) -> bool:
-        """
-        Returns `True` if a record for combination of a well and a run exists,
-        in the well metrics table `False` otherwise.
-        """
-
-        return bool(self.get_well(run_name, well_label))
 
     def recent_completed_wells(self) -> List[PacBioRunWellMetrics]:
         """

--- a/lang_qc/endpoints/pacbio_well.py
+++ b/lang_qc/endpoints/pacbio_well.py
@@ -201,8 +201,8 @@ def claim_qc(
     _validate_product_id_or_error(id_product)
     mlwh_well = _find_well_product_or_error(id_product, mlwhdb_session)
 
-    well_qc = WellQc(session=qcdb_session, id_product=id_product, mlwh_well=mlwh_well)
-    if well_qc.current_qc_state():
+    well_qc = WellQc(session=qcdb_session)
+    if well_qc.current_qc_state(id_product):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Well for product {id_product} has already been claimed",
@@ -243,8 +243,8 @@ def assign_qc_state(
     _validate_product_id_or_error(id_product)
     mlwh_well = _find_well_product_or_error(id_product, mlwhdb_session)
 
-    well_qc = WellQc(session=qcdb_session, id_product=id_product)
-    qc_state = well_qc.current_qc_state()
+    well_qc = WellQc(session=qcdb_session)
+    qc_state = well_qc.current_qc_state(id_product)
 
     if qc_state is None:
         raise HTTPException(

--- a/lang_qc/endpoints/pacbio_well.py
+++ b/lang_qc/endpoints/pacbio_well.py
@@ -161,24 +161,14 @@ def get_seq_metrics(
     qcdb_session: Session = Depends(get_qc_db),
 ) -> PacBioWellFull:
 
-    try:
-        check_product_id_is_valid(id_product=id_product)
-    except ValidationError as err:
-        raise HTTPException(422, detail=" ".join([e["msg"] for e in err.errors()]))
-
-    mlwh_well = WellWh(session=mlwhdb_session).get_mlwh_well_by_product_id(
-        id_product=id_product
-    )
-    if mlwh_well is None:
-        raise HTTPException(
-            404, detail=f"PacBio well for product ID {id_product} not found."
-        )
+    _validate_product_id_or_error(id_product)
+    mlwh_well = _find_well_product_or_error(id_product, mlwhdb_session)
 
     return PacBioWellFull.from_orm(mlwh_well, qcdb_session)
 
 
 @router.post(
-    "/run/{run_name}/well/{well_label}/qc_claim",
+    "/products/{id_product}/qc_claim",
     summary="Claim the well to start QC",
     description="""
     Enables the user to initiate manual QC of the well. The resulting QC state
@@ -202,38 +192,29 @@ def get_seq_metrics(
     status_code=status.HTTP_201_CREATED,
 )
 def claim_qc(
-    run_name: str,
-    well_label: str,
+    id_product: str,
     user: User = Depends(check_user),
     qcdb_session: Session = Depends(get_qc_db),
     mlwhdb_session: Session = Depends(get_mlwh_db),
 ) -> QcState:
 
-    if (
-        WellWh(session=mlwhdb_session).well_exists(
-            run_name=run_name, well_label=well_label
-        )
-        is False
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Well {well_label} run {run_name} does not exist",
-        )
+    _validate_product_id_or_error(id_product)
+    mlwh_well = _find_well_product_or_error(id_product, mlwhdb_session)
 
-    well_qc = WellQc(session=qcdb_session, run_name=run_name, well_label=well_label)
+    well_qc = WellQc(session=qcdb_session, id_product=id_product, mlwh_well=mlwh_well)
     if well_qc.current_qc_state():
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"Well {well_label} run {run_name} has already been claimed",
+            detail=f"Well for product {id_product} has already been claimed",
         )
 
     # Using default attributes for almost all arguments.
     # The new QC state will be set as preliminary.
-    return QcState.from_orm(well_qc.assign_qc_state(user=user))
+    return QcState.from_orm(well_qc.assign_qc_state(mlwh_well=mlwh_well, user=user))
 
 
 @router.put(
-    "/run/{run_name}/well/{well_label}/qc_assign",
+    "/products/{id_product}/qc_assign",
     summary="Assign QC state to a well",
     description="""
     Enables the user to assign a new QC state to a well. The well QC should
@@ -252,14 +233,17 @@ def claim_qc(
     response_model=QcState,
 )
 def assign_qc_state(
-    run_name: str,
-    well_label: str,
+    id_product: str,
     request_body: QcStateBasic,
     user: User = Depends(check_user),
     qcdb_session: Session = Depends(get_qc_db),
+    mlwhdb_session: Session = Depends(get_mlwh_db),
 ) -> QcState:
 
-    well_qc = WellQc(session=qcdb_session, run_name=run_name, well_label=well_label)
+    _validate_product_id_or_error(id_product)
+    mlwh_well = _find_well_product_or_error(id_product, mlwhdb_session)
+
+    well_qc = WellQc(session=qcdb_session, id_product=id_product)
     qc_state = well_qc.current_qc_state()
 
     if qc_state is None:
@@ -271,7 +255,9 @@ def assign_qc_state(
     qc_state = None
     message = "Error assigning status: "
     try:
-        qc_state = well_qc.assign_qc_state(user=user, **request_body.dict())
+        qc_state = well_qc.assign_qc_state(
+            mlwh_well=mlwh_well, user=user, **request_body.dict()
+        )
     except (InvalidDictValueError, InconsistentInputError) as err:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -279,3 +265,22 @@ def assign_qc_state(
         )
 
     return QcState.from_orm(qc_state)
+
+
+def _validate_product_id_or_error(id_product):
+    try:
+        check_product_id_is_valid(id_product=id_product)
+    except ValidationError as err:
+        raise HTTPException(422, detail=" ".join([e["msg"] for e in err.errors()]))
+
+
+def _find_well_product_or_error(id_product, mlwhdb_session):
+
+    mlwh_well = WellWh(session=mlwhdb_session).get_mlwh_well_by_product_id(
+        id_product=id_product
+    )
+    if mlwh_well is None:
+        raise HTTPException(
+            404, detail=f"PacBio well for product ID {id_product} not found."
+        )
+    return mlwh_well

--- a/tests/endpoints/test_assign_qc_state.py
+++ b/tests/endpoints/test_assign_qc_state.py
@@ -1,93 +1,103 @@
-import json
-
 from fastapi.testclient import TestClient
 from npg_id_generation.pac_bio import PacBioEntity
 
-from tests.fixtures.inbox_data import test_data_factory
+from tests.fixtures.well_data import load_data4well_retrieval, load_dicts_and_users
+
+id_product_2A1 = PacBioEntity(
+    run_name="TRACTION_RUN_2", well_label="A1", plate_number=1
+).hash_product_id()
+post_data = """
+{
+    "qc_type": "sequencing",
+    "qc_state": "Passed",
+    "is_preliminary": true
+}
+"""
 
 
-def test_change_non_existent_well(test_client: TestClient, test_data_factory):
-    """Expect an error if we try to assign a state to a well which doesn't exist."""
-
-    test_data = {
-        "DONT-USE-THIS-RUN": {"A1": None, "B1": None},
-        "NOR-THIS-ONE": {"A1": "Passed", "B1": "Failed"},
-    }
-    test_data_factory(test_data)
-
-    post_data = """
-        {
-          "qc_type": "library",
-          "qc_state": "Passed",
-          "is_preliminary": true
-        }
-    """
+def test_error_invalid_product_id(test_client: TestClient, load_data4well_retrieval):
+    """Error if product ID validation fails."""
 
     response = test_client.put(
-        "/pacbio/run/NONEXISTENT/well/A10/qc_assign",
+        "/pacbio/products/12345q/qc_assign",
         post_data,
         headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
     )
+    assert response.status_code == 422
+    assert response.json()["detail"].startswith("string does not match regex")
 
+
+def test_error_nonexistent_well(test_client: TestClient, load_data4well_retrieval):
+    """Expect an error if we try to update a well which doesn't exist."""
+
+    id = 32 * "a" + 32 * "b"
+    response = test_client.put(
+        f"/pacbio/products/{id}/qc_assign",
+        post_data,
+        headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"PacBio well for product ID {id} not found."
+
+
+def test_error_unknown_user(test_client: TestClient, load_data4well_retrieval):
+    """Expect an error when updating a well as an unknown user."""
+
+    response = test_client.put(
+        f"/pacbio/products/{id_product_2A1}/qc_assign",
+        post_data,
+        headers={"OIDC_CLAIM_EMAIL": "intruder@example.com"},
+    )
+    assert response.status_code == 403
+    assert (
+        response.json()["detail"]
+        == "The user is not authorized to perform this operation."
+    )
+
+
+def test_error_no_user(test_client: TestClient, load_data4well_retrieval):
+    """Expect an error when updating a well if no user is in the header."""
+
+    response = test_client.put(
+        f"/pacbio/products/{id_product_2A1}/qc_assign", post_data
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"] == "No user provided, is the user logged in?"
+
+
+def test_error_updating_unclaimed_well(
+    test_client: TestClient, load_data4well_retrieval
+):
+    """Expect an error when updating an unclaimed well."""
+
+    id_product_15A1 = PacBioEntity(
+        run_name="TRACTION_RUN_15", well_label="A1", plate_number=1
+    ).hash_product_id()
+    response = test_client.put(
+        f"/pacbio/products/{id_product_15A1}/qc_assign",
+        post_data,
+        headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
+    )
     assert response.status_code == 409
     assert (
         response.json()["detail"] == "QC state of an unclaimed well cannot be updated"
     )
 
 
-def test_change_outcome(test_client: TestClient, test_data_factory):
-    """Successfully change a state from passed to failed"""
+def test_error_inconsistent_preliminary_flag(
+    test_client: TestClient, load_data4well_retrieval
+):
 
-    test_data = {
-        "MARATHON": {"A1": "Passed", "B1": None},
-        "SEMI-MARATHON": {"D1": "Claimed"},
+    post_data_prelim = """
+    {
+        "qc_type": "sequencing",
+        "qc_state": "On hold",
+        "is_preliminary": false
     }
-    test_data_factory(test_data)
-
-    post_data = """
-        {
-          "qc_type": "library",
-          "qc_state": "Failed",
-          "is_preliminary": false
-        }
-    """
-
-    response = test_client.put(
-        "/pacbio/run/MARATHON/well/A1/qc_assign",
-        post_data,
-        headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
-    )
-    content = response.json()
-
-    assert response.status_code == 200
-
-    expected = {
-        "id_product": PacBioEntity(
-            run_name="MARATHON", well_label="A1"
-        ).hash_product_id(),
-        "user": "zx80@example.com",
-        "qc_type": "library",
-        "qc_state": "Failed",
-        "is_preliminary": False,
-        "created_by": "LangQC",
-        "outcome": False,
-    }
-
-    for key, value in expected.items():
-        assert content[key] == value
-    for date_key in ("date_created", "date_updated"):
-        assert content[date_key] is not None
-
-    post_data = """
-        {
-          "qc_type": "library",
-          "qc_state": "On hold",
-          "is_preliminary": false
-        }
     """
     response = test_client.put(
-        "/pacbio/run/MARATHON/well/A1/qc_assign",
-        post_data,
+        f"/pacbio/products/{id_product_2A1}/qc_assign",
+        post_data_prelim,
         headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
     )
     assert response.status_code == 400
@@ -96,16 +106,66 @@ def test_change_outcome(test_client: TestClient, test_data_factory):
         == "Error assigning status: QC state 'On hold' cannot be final"
     )
 
-    post_data = """
-        {
-          "qc_type": "library",
-          "qc_state": "On hold",
-          "is_preliminary": true
-        }
+
+def test_error_invalid_state(test_client: TestClient, load_data4well_retrieval):
+    """Test error when an invalid state is provided."""
+
+    post_data_state = """
+    {
+        "qc_type": "sequencing",
+        "qc_state": "On reprimand",
+        "is_preliminary": false
+    }
     """
     response = test_client.put(
-        "/pacbio/run/MARATHON/well/A1/qc_assign",
+        f"/pacbio/products/{id_product_2A1}/qc_assign",
+        post_data_state,
+        headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
+    )
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "Error assigning status: QC state 'On reprimand' is invalid"
+    )
+
+
+def test_change_outcome(test_client: TestClient, load_data4well_retrieval):
+    """Successfully change a state from passed to failed"""
+
+    response = test_client.put(
+        f"/pacbio/products/{id_product_2A1}/qc_assign",
         post_data,
+        headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
+    )
+    content = response.json()
+
+    assert response.status_code == 200
+
+    expected = {
+        "id_product": id_product_2A1,
+        "user": "zx80@example.com",
+        "qc_type": "sequencing",
+        "qc_state": "Passed",
+        "is_preliminary": True,
+        "created_by": "LangQC",
+        "outcome": True,
+    }
+
+    for key, value in expected.items():
+        assert content[key] == value
+    for date_key in ("date_created", "date_updated"):
+        assert content[date_key] is not None
+
+    post_data_update = """
+    {
+        "qc_type": "sequencing",
+        "qc_state": "On hold",
+        "is_preliminary": true
+    }
+    """
+    response = test_client.put(
+        f"/pacbio/products/{id_product_2A1}/qc_assign",
+        post_data_update,
         headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
     )
     content = response.json()
@@ -117,105 +177,3 @@ def test_change_outcome(test_client: TestClient, test_data_factory):
     assert response.status_code == 200
     for key, value in expected.items():
         assert content[key] == value
-
-
-def test_error_on_invalid_state(test_client: TestClient, test_data_factory):
-    """Test error when an invalid state is provided."""
-
-    test_data = {
-        "MARATHON": {"A1": "Passed", "B1": None},
-        "SEMI-MARATHON": {"D1": "Claimed"},
-    }
-    test_data_factory(test_data)
-
-    post_data = {
-        "qc_type": "library",
-        "qc_state": "NotDoingAnything",
-        "is_preliminary": False,
-    }
-
-    response = test_client.put(
-        "/pacbio/run/SEMI-MARATHON/well/D1/qc_assign",
-        json.dumps(post_data),
-        headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
-    )
-
-    assert response.status_code == 400
-    assert (
-        response.json()["detail"]
-        == "Error assigning status: QC state 'NotDoingAnything' is invalid"
-    )
-
-
-def test_error_on_unknown_user(test_client: TestClient, test_data_factory):
-    """Test error when an unkown user makes a request."""
-
-    test_data = {
-        "MARATHON": {"A1": "Passed", "B1": None},
-        "SEMI-MARATHON": {"D1": "Claimed"},
-    }
-    test_data_factory(test_data)
-
-    post_data = {
-        "qc_type": "library",
-        "qc_state": "Failed",
-        "is_preliminary": False,
-    }
-
-    response = test_client.put(
-        "/pacbio/run/SEMI-MARATHON/well/D1/qc_assign",
-        json.dumps(post_data),
-        headers={"OIDC_CLAIM_EMAIL": "intruder@example.com"},
-    )
-
-    assert response.status_code == 403
-    assert (
-        response.json()["detail"]
-        == "The user is not authorized to perform this operation."
-    )
-
-
-def test_error_on_unclaimed_well(test_client: TestClient, test_data_factory):
-    """Test error on assigning a new state to an unclaimed well."""
-
-    test_data = {"MARATHON": {"A1": None, "B1": None}}
-    test_data_factory(test_data)
-
-    post_data = {
-        "qc_type": "library",
-        "qc_state": "Passed",
-        "is_preliminary": True,
-    }
-
-    response = test_client.put(
-        "/pacbio/run/MARATHON/well/A1/qc_assign",
-        json.dumps(post_data),
-        headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
-    )
-
-    assert response.status_code == 409
-    assert (
-        response.json()["detail"] == "QC state of an unclaimed well cannot be updated"
-    )
-
-
-def test_preclaimed_well(test_client: TestClient, test_data_factory):
-    """Other valid users should be able to set new QC states."""
-
-    test_data = {"MARATHON": {"A1": "Passed", "B1": None}}
-    test_data_factory(test_data)
-
-    post_data = {
-        "qc_type": "library",
-        "qc_state": "Failed",
-        "is_preliminary": True,
-    }
-
-    response = test_client.put(
-        "/pacbio/run/MARATHON/well/A1/qc_assign",
-        json.dumps(post_data),
-        headers={"OIDC_CLAIM_EMAIL": "cd32@example.com"},
-    )
-
-    assert response.status_code == 200
-    assert response.json()["qc_state"] == "Failed"

--- a/tests/endpoints/test_claim_well.py
+++ b/tests/endpoints/test_claim_well.py
@@ -3,51 +3,73 @@ from datetime import datetime
 from fastapi.testclient import TestClient
 from npg_id_generation.pac_bio import PacBioEntity
 
-from tests.fixtures.inbox_data import test_data_factory
+from tests.fixtures.well_data import load_data4well_retrieval, load_dicts_and_users
+
+id_product_15A1 = PacBioEntity(
+    run_name="TRACTION_RUN_15", well_label="A1", plate_number=1
+).hash_product_id()
 
 
-def test_claim_nonexistent_well(test_client: TestClient, test_data_factory):
-    """Expect an error if we try to claim a well which doesn't exist."""
-
-    test_data = {
-        "DONT-USE-THIS-RUN": {"A1": None, "B1": None},
-        "NOR-THIS-ONE": {"A1": "Passed", "B1": "Failed"},
-    }
-    test_data_factory(test_data)
+def test_claim_invalid_product_id(test_client: TestClient, load_data4well_retrieval):
+    """Error if product ID validation fails."""
 
     response = test_client.post(
-        "/pacbio/run/NONEXISTENT/well/A0/qc_claim",
+        "/pacbio/products/12345q/qc_claim",
         headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
     )
+    assert response.status_code == 422
+    assert response.json()["detail"].startswith("string does not match regex")
 
+
+def test_claim_nonexistent_well(test_client: TestClient, load_data4well_retrieval):
+    """Expect an error if we try to claim a well which doesn't exist."""
+
+    id = 32 * "a" + 32 * "b"
+    response = test_client.post(
+        f"/pacbio/products/{id}/qc_claim",
+        headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
+    )
     assert response.status_code == 404
-    assert response.json()["detail"] == "Well A0 run NONEXISTENT does not exist"
+    assert response.json()["detail"] == f"PacBio well for product ID {id} not found."
 
 
-def test_claim_well_simple(test_client: TestClient, test_data_factory):
+def test_claim_well_unknown_user(test_client: TestClient, load_data4well_retrieval):
+    """Expect an error when claiming a well as an unknown user."""
+
+    response = test_client.post(
+        f"/pacbio/products/{id_product_15A1}/qc_claim",
+        headers={"OIDC_CLAIM_EMAIL": "intruder@example.com"},
+    )
+    assert response.status_code == 403
+    assert (
+        response.json()["detail"]
+        == "The user is not authorized to perform this operation."
+    )
+
+
+def test_error_on_no_user(test_client: TestClient, load_data4well_retrieval):
+    """Expect an error when claiming a well if no user is in the header."""
+
+    response = test_client.post(f"/pacbio/products/{id_product_15A1}/qc_claim")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "No user provided, is the user logged in?"
+
+
+def test_claim_well_successful(test_client: TestClient, load_data4well_retrieval):
     """Successfully claim an unclaimed well."""
-
-    test_data = {
-        "MARATHON": {"A1": None, "B1": None},
-        "SEMI-MARATHON": {"D1": "Claimed", "A1": "Passed"},
-    }
-    test_data_factory(test_data)
 
     time_now = datetime.now()
 
     response = test_client.post(
-        "/pacbio/run/MARATHON/well/B1/qc_claim",
+        f"/pacbio/products/{id_product_15A1}/qc_claim",
         headers={"oidc_claim_email": "zx80@example.com"},
     )
-
     assert response.status_code == 201
 
     actual_content = response.json()
 
     expected = {
-        "id_product": PacBioEntity(
-            run_name="MARATHON", well_label="B1"
-        ).hash_product_id(),
+        "id_product": id_product_15A1,
         "user": "zx80@example.com",
         "qc_type": "sequencing",
         "qc_state": "Claimed",
@@ -65,60 +87,15 @@ def test_claim_well_simple(test_client: TestClient, test_data_factory):
         assert delta.total_seconds() <= 1
 
 
-def test_claim_well_unknown_user(test_client: TestClient, test_data_factory):
-    """Expect an error when claiming a well as an unknown user."""
-
-    test_data = {
-        "MARATHON": {"A1": None, "B1": None},
-        "SEMI-MARATHON": {"D1": "Claimed", "A1": "Passed"},
-    }
-    test_data_factory(test_data)
-
-    response = test_client.post(
-        "/pacbio/run/MARATHON/well/B1/qc_claim",
-        headers={"OIDC_CLAIM_EMAIL": "intruder@example.com"},
-    )
-
-    assert response.status_code == 403
-    assert (
-        response.json()["detail"]
-        == "The user is not authorized to perform this operation."
-    )
-
-
-def test_error_on_no_user(test_client: TestClient, test_data_factory):
-    """Expect an error when claiming a well if no user is in the header."""
-
-    test_data = {"MARATHON": {"A1": "Failed", "B1": None}}
-
-    test_data_factory(test_data)
-
-    for well_label in "A1", "B1":
-
-        response = test_client.post(f"/pacbio/run/MARATHON/well/{well_label}/qc_claim")
-
-        assert response.status_code == 401
-        assert response.json()["detail"] == "No user provided, is the user logged in?"
-
-
-def test_error_on_already_claimed(test_client: TestClient, test_data_factory):
+def test_error_on_already_claimed(test_client: TestClient, load_data4well_retrieval):
     """Expect an error when claiming a well which has already been claimed"""
 
-    test_data = {
-        "MARATHON": {"A1": "Failed", "B1": "On hold"},
-        "SEMI-MARATHON": {"D1": "Claimed", "A1": "Passed"},
-    }
-    test_data_factory(test_data)
-
-    for run_name in test_data:
-        for well_label in test_data[run_name]:
-
-            response = test_client.post(
-                f"/pacbio/run/{run_name}/well/{well_label}/qc_claim",
-                headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
-            )
-            assert response.status_code == 409
-            assert (
-                response.json()["detail"]
-                == f"Well {well_label} run {run_name} has already been claimed"
-            )
+    response = test_client.post(
+        f"/pacbio/products/{id_product_15A1}/qc_claim",
+        headers={"OIDC_CLAIM_EMAIL": "zx80@example.com"},
+    )
+    assert response.status_code == 409
+    assert (
+        response.json()["detail"]
+        == f"Well for product {id_product_15A1} has already been claimed"
+    )

--- a/tests/endpoints/test_filtered_wells.py
+++ b/tests/endpoints/test_filtered_wells.py
@@ -84,6 +84,7 @@ def test_on_hold_filter(test_client: TestClient, load_data4well_retrieval):
     expected_data = [
         {"TRACTION_RUN_1:D1": "On hold"},
         {"TRACTION_RUN_1:B1": "On hold"},
+        {"TRACTION_RUN_16:A1": "On hold"},
     ]
     num_total = len(expected_data)
 
@@ -116,6 +117,7 @@ def test_in_progress_filter(test_client: TestClient, load_data4well_retrieval):
         {"TRACTION_RUN_1:C1": "Claimed"},
         {"TRACTION_RUN_2:A1": "Failed, Instrument"},
         {"TRACTION_RUN_1:A1": "Claimed"},
+        {"TRACTION_RUN_16:A1": "Claimed"},
         {"TRACTION_RUN_7:A1": "Failed"},
     ]
     # One entity is removed after paging since no mlwh data is available
@@ -130,7 +132,12 @@ def test_in_progress_filter(test_client: TestClient, load_data4well_retrieval):
     response = test_client.get(
         "/pacbio/wells?qc_status=in_progress&page_size=5&page_number=2"
     )
-    _assert_filtered_results(response, expected_data[5:], 5, 2, num_total)
+    _assert_filtered_results(response, expected_data[5:9], 5, 2, num_total)
+
+    response = test_client.get(
+        "/pacbio/wells?qc_status=in_progress&page_size=5&page_number=3"
+    )
+    _assert_filtered_results(response, expected_data[9:], 5, 3, num_total)
 
 
 def test_inbox_filter(test_client: TestClient, load_data4well_retrieval):

--- a/tests/fixtures/well_data.py
+++ b/tests/fixtures/well_data.py
@@ -79,6 +79,8 @@ QC_DATA = [
     ["TRACTION_RUN_6", "A1", "Aborted", True, "2022-12-15 11:42:33", 1],
     ["TRACTION_RUN_6", "B1", "Aborted", True, "2022-12-15 10:42:33", 1],
     ["TRACTION_RUN_7", "A1", "Failed", True, "2022-02-15 10:42:33", 1],
+    ["TRACTION_RUN_16", "A1", "Claimed", True, "2022-02-15 10:42:34", 1],
+    ["TRACTION_RUN_16", "A1", "On hold", True, "2022-02-15 10:42:35", 2],
 ]
 
 # A set of fake warehouse entries for the QC states above.
@@ -741,6 +743,38 @@ MLWH_DATA = [
         "1234",
         "Revio",
         1,
+    ],
+    [
+        "TRACTION_RUN_16",
+        "A1",
+        "2022-06-11 11:15:41",
+        "2022-06-16 07:39:59",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "1234",
+        "Revio",
+        1,
+    ],
+    [
+        "TRACTION_RUN_16",
+        "A1",
+        "2022-06-11 11:15:41",
+        "2022-06-16 07:39:59",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "1234",
+        "Revio",
+        2,
     ],
 ]
 

--- a/tests/fixtures/well_data.py
+++ b/tests/fixtures/well_data.py
@@ -659,8 +659,8 @@ MLWH_DATA = [
         3989714,
         2227107,
         "1234",
-        "Revio",
-        1,
+        "Sequel2",
+        None,
     ],
     [
         "SUBTRACTION_RUN_15",

--- a/tests/fixtures/well_data.py
+++ b/tests/fixtures/well_data.py
@@ -4,9 +4,17 @@ import pytest
 from npg_id_generation.pac_bio import PacBioEntity
 from sqlalchemy import insert, select
 
-from lang_qc.db.helper.well import WellQc
 from lang_qc.db.mlwh_schema import PacBioRunWellMetrics
-from lang_qc.db.qc_schema import QcStateDict, QcType, SeqPlatform, SubProductAttr, User
+from lang_qc.db.qc_schema import (
+    QcState,
+    QcStateDict,
+    QcType,
+    SeqPlatform,
+    SeqProduct,
+    SubProduct,
+    SubProductAttr,
+    User,
+)
 
 QC_TYPES = [
     {"qc_type": "sequencing", "description": "Sequencing process evaluation"},
@@ -36,6 +44,7 @@ ATTRIBUTE_NAMES = [
         "description": "The name of the PacBio run according to LIMS",
     },
     {"attr_name": "well_label", "description": "PacBio well (or cell) label"},
+    {"attr_name": "plate_number", "description": "PacBio plate number"},
     {
         "attr_name": "flowcell_id",
         "description": "ONT flowcell id as recorded by the instrument",
@@ -51,24 +60,25 @@ USERS = [
 ]
 
 # A combination of all QC states and final/not final.
-# Data in each list: run name, well label, qc state description, is_preliminary flag, date
+# Data in each list: run name, well label, qc state description,
+# is_preliminary flag, date, plate number
 QC_DATA = [
-    ["TRACTION_RUN_1", "A1", "Claimed", True, "2022-12-07 07:15:19"],
-    ["TRACTION_RUN_1", "B1", "On hold", True, "2022-12-08 07:15:19"],
-    ["TRACTION_RUN_1", "C1", "Claimed", True, "2022-12-08 08:15:19"],
-    ["TRACTION_RUN_1", "D1", "On hold", True, "2022-12-08 09:15:19"],
-    ["TRACTION_RUN_1", "E1", "Claimed", True, "2022-12-07 09:15:19"],
-    ["TRACTION_RUN_2", "A1", "Failed, Instrument", True, "2022-12-07 15:13:56"],
-    ["TRACTION_RUN_2", "B1", "Failed, Instrument", False, "2022-12-08 15:18:56"],
-    ["TRACTION_RUN_2", "C1", "Failed, SMRT cell", True, "2022-12-08 18:14:56"],
-    ["TRACTION_RUN_2", "D1", "Failed, SMRT cell", False, "2022-12-07 15:23:56"],
-    ["TRACTION_RUN_4", "A1", "Failed", True, "2022-12-12 16:02:57"],
-    ["TRACTION_RUN_4", "B1", "Failed", False, "2022-12-12 12:02:57"],
-    ["TRACTION_RUN_5", "A1", "Passed", True, "2022-12-22 16:21:06"],
-    ["TRACTION_RUN_5", "B1", "Passed", False, "2022-12-21 14:21:06"],
-    ["TRACTION_RUN_6", "A1", "Aborted", True, "2022-12-15 11:42:33"],
-    ["TRACTION_RUN_6", "B1", "Aborted", True, "2022-12-15 10:42:33"],
-    ["TRACTION_RUN_7", "A1", "Failed", True, "2022-02-15 10:42:33"],
+    ["TRACTION_RUN_1", "A1", "Claimed", True, "2022-12-07 07:15:19", None],
+    ["TRACTION_RUN_1", "B1", "On hold", True, "2022-12-08 07:15:19", None],
+    ["TRACTION_RUN_1", "C1", "Claimed", True, "2022-12-08 08:15:19", None],
+    ["TRACTION_RUN_1", "D1", "On hold", True, "2022-12-08 09:15:19", None],
+    ["TRACTION_RUN_1", "E1", "Claimed", True, "2022-12-07 09:15:19", None],
+    ["TRACTION_RUN_2", "A1", "Failed, Instrument", True, "2022-12-07 15:13:56", 1],
+    ["TRACTION_RUN_2", "B1", "Failed, Instrument", False, "2022-12-08 15:18:56", 1],
+    ["TRACTION_RUN_2", "C1", "Failed, SMRT cell", True, "2022-12-08 18:14:56", 1],
+    ["TRACTION_RUN_2", "D1", "Failed, SMRT cell", False, "2022-12-07 15:23:56", 1],
+    ["TRACTION_RUN_4", "A1", "Failed", True, "2022-12-12 16:02:57", 1],
+    ["TRACTION_RUN_4", "B1", "Failed", False, "2022-12-12 12:02:57", 1],
+    ["TRACTION_RUN_5", "A1", "Passed", True, "2022-12-22 16:21:06", None],
+    ["TRACTION_RUN_5", "B1", "Passed", False, "2022-12-21 14:21:06", None],
+    ["TRACTION_RUN_6", "A1", "Aborted", True, "2022-12-15 11:42:33", 1],
+    ["TRACTION_RUN_6", "B1", "Aborted", True, "2022-12-15 10:42:33", 1],
+    ["TRACTION_RUN_7", "A1", "Failed", True, "2022-02-15 10:42:33", 1],
 ]
 
 # A set of fake warehouse entries for the QC states above.
@@ -756,21 +766,66 @@ def load_data4well_retrieval(
 
     users = qcdb_test_session.execute(select(User)).scalars().all()
 
-    # Each record will be committed individually
+    db_types = qcdb_test_session.execute(select(QcType)).scalars().all()
+    qc_types = {row.qc_type: row for row in db_types}
+
+    db_states = qcdb_test_session.execute(select(QcStateDict)).scalars().all()
+    qc_states = {row.state: row for row in db_states}
+
+    platform = qcdb_test_session.execute(
+        select(SeqPlatform).where(SeqPlatform.name == "PacBio")
+    ).scalar_one()
+
+    product_attr_rn = qcdb_test_session.execute(
+        select(SubProductAttr).where(SubProductAttr.attr_name == "run_name")
+    ).scalar_one()
+    product_attr_wl = qcdb_test_session.execute(
+        select(SubProductAttr).where(SubProductAttr.attr_name == "well_label")
+    ).scalar_one()
+    product_attr_pn = qcdb_test_session.execute(
+        select(SubProductAttr).where(SubProductAttr.attr_name == "plate_number")
+    ).scalar_one()
+
     for qc_data in QC_DATA:
-        helper = WellQc(
-            session=qcdb_test_session, run_name=qc_data[0], well_label=qc_data[1]
+
+        pbe = PacBioEntity(
+            run_name=qc_data[0], well_label=qc_data[1], plate_number=qc_data[5]
         )
-        # Create data for both QC types.
-        for qc_type_definition in QC_TYPES:
-            qc_type = qc_type_definition["qc_type"]
-            helper.assign_qc_state(
-                user=users[0],
-                qc_state=qc_data[2],
+        id_product = pbe.hash_product_id()
+        json = pbe.json()
+        date = datetime.strptime(qc_data[4], DATE_FORMAT)
+
+        seq_product = SeqProduct(
+            id_product=id_product,
+            seq_platform=platform,
+            sub_products=[
+                SubProduct(
+                    sub_product_attr=product_attr_rn,
+                    sub_product_attr_=product_attr_wl,
+                    sub_product_attr__=product_attr_pn,
+                    value_attr_one=qc_data[0],
+                    value_attr_two=qc_data[1],
+                    properties=json,
+                    properties_digest=id_product,
+                ),
+            ],
+        )
+        qcdb_test_session.add(seq_product)
+
+        for qc_type in ["sequencing", "library"]:
+            qc_state = QcState(
+                created_by="LangQC",
                 is_preliminary=qc_data[3],
-                date_updated=datetime.strptime(qc_data[4], DATE_FORMAT),
-                qc_type=qc_type,
+                qc_state_dict=qc_states[qc_data[2]],
+                qc_type=qc_types[qc_type],
+                date_created=date,
+                date_updated=date,
+                seq_product=seq_product,
+                user=users[0],
             )
+            qcdb_test_session.add(qc_state)
+
+    qcdb_test_session.commit()
 
     # We want some wells to be in the inbox. For that their run_complete dates
     # should be within last four weeks. Therefore, we need to update the timestamps

--- a/tests/test_pac_bio_qc_data_well.py
+++ b/tests/test_pac_bio_qc_data_well.py
@@ -1,3 +1,5 @@
+from npg_id_generation.pac_bio import PacBioEntity
+
 from lang_qc.db.helper.wells import WellWh
 from lang_qc.models.pacbio.qc_data import QCDataWell
 from tests.conftest import insert_from_yaml
@@ -11,9 +13,13 @@ def test_creating_qc_data_well(mlwhdb_test_session):
     insert_from_yaml(
         mlwhdb_test_session, "tests/data/mlwh_pb_demux_525", "lang_qc.db.mlwh_schema"
     )
+
     helper = WellWh(session=mlwhdb_test_session)
 
-    row = helper.get_well("TRACTION-RUN-525", "A1")
+    id_product = PacBioEntity(
+        run_name="TRACTION-RUN-525", well_label="A1"
+    ).hash_product_id()
+    row = helper.get_mlwh_well_by_product_id(id_product)
 
     qc = QCDataWell.from_orm(row)
 
@@ -85,7 +91,10 @@ def test_creating_qc_data_well(mlwhdb_test_session):
     }, "Demultiplexed percentages are calculated"
 
     # and check the less populated data leads to Nones
-    row = helper.get_well("TRACTION-RUN-92", "A1")
+    id_product = PacBioEntity(
+        run_name="TRACTION-RUN-92", well_label="A1"
+    ).hash_product_id()
+    row = helper.get_mlwh_well_by_product_id(id_product)
     qc = QCDataWell.from_orm(row)
 
     assert (

--- a/tests/test_pac_well_full.py
+++ b/tests/test_pac_well_full.py
@@ -1,3 +1,5 @@
+from npg_id_generation.pac_bio import PacBioEntity
+
 from lang_qc.db.helper.wells import WellWh
 from lang_qc.models.pacbio.well import PacBioWellFull
 from tests.conftest import compare_dates, insert_from_yaml
@@ -14,12 +16,16 @@ def test_creating_experiment_object(
     helper = WellWh(session=mlwhdb_test_session)
 
     # Full mlwh data, no data in the lang_qc database.
-    run_name = "TRACTION-RUN-92"
-    well_row = helper.get_well(run_name, "A1")
+    id_product = PacBioEntity(
+        run_name="TRACTION-RUN-92", well_label="A1"
+    ).hash_product_id()
+    well_row = helper.get_mlwh_well_by_product_id(id_product)
 
     pb_well = PacBioWellFull.from_orm(well_row, qcdb_test_session)
-    assert pb_well.run_name == run_name
+    assert pb_well.id_product == id_product
+    assert pb_well.run_name == "TRACTION-RUN-92"
     assert pb_well.label == "A1"
+    assert pb_well.plate_number is None
     assert pb_well.qc_state is None
     compare_dates(pb_well.run_start_time, "2022-04-14 12:52:34")
     compare_dates(pb_well.run_complete_time, "2022-04-20 09:16:53")
@@ -34,12 +40,16 @@ def test_creating_experiment_object(
 
     # Only run_well mlwh data (no products), and data in the lang_qc database.
     # Very sketchy mlwh qc metrics data
-    run_name = "TRACTION_RUN_1"
-    well_row = helper.get_well(run_name, "B1")
+    id_product = PacBioEntity(
+        run_name="TRACTION_RUN_1", well_label="B1"
+    ).hash_product_id()
+    well_row = helper.get_mlwh_well_by_product_id(id_product)
 
     pb_well = PacBioWellFull.from_orm(well_row, qcdb_test_session)
-    assert pb_well.run_name == run_name
+    assert pb_well.id_product == id_product
+    assert pb_well.run_name == "TRACTION_RUN_1"
     assert pb_well.label == "B1"
+    assert pb_well.plate_number is None
     assert pb_well.run_status == "Complete"
     assert pb_well.well_status == "Complete"
     assert pb_well.qc_state is not None
@@ -50,12 +60,16 @@ def test_creating_experiment_object(
 
     # Only run_well mlwh data (no products), no data in the lang_qc database.
     # Very sketchy mlwh qc metrics data
-    run_name = "TRACTION_RUN_10"
-    well_row = helper.get_well(run_name, "C1")
+    id_product = PacBioEntity(
+        run_name="TRACTION_RUN_10", well_label="C1"
+    ).hash_product_id()
+    well_row = helper.get_mlwh_well_by_product_id(id_product)
 
     pb_well = PacBioWellFull.from_orm(well_row, qcdb_test_session)
-    assert pb_well.run_name == run_name
+    assert pb_well.id_product == id_product
+    assert pb_well.run_name == "TRACTION_RUN_10"
     assert pb_well.label == "C1"
+    assert pb_well.plate_number == 1
     assert pb_well.well_status == "Complete"
     assert pb_well.run_status == "Aborted"
     assert pb_well.qc_state is None

--- a/tests/test_pb_wells_factory.py
+++ b/tests/test_pb_wells_factory.py
@@ -22,7 +22,7 @@ def test_query_for_status(
     )
     query = factory._build_query4status(QcFlowStatusEnum.ON_HOLD)
     states = qcdb_test_session.execute(query).scalars().all()
-    assert len(states) == 2
+    assert len(states) == 3
     # The results should be sorted by the update date in a descending order.
     update_dates = ["2022-12-08 09:15:19", "2022-12-08 07:15:19"]
     for index in (0, 1):
@@ -43,6 +43,7 @@ def test_query_for_status(
     states = qcdb_test_session.execute(query).scalars().all()
     expected_data = [
         ["Failed", "2022-02-15 10:42:33"],
+        ["Claimed", "2022-02-15 10:42:34"],
         ["Claimed", "2022-12-07 07:15:19"],
         ["Claimed", "2022-12-07 09:15:19"],
         ["Failed, Instrument", "2022-12-07 15:13:56"],
@@ -170,8 +171,8 @@ def test_paged_retrieval_for_statuses(
 ):
 
     expected_page_details = {
-        QcFlowStatusEnum.IN_PROGRESS.name: 10,
-        QcFlowStatusEnum.ON_HOLD.name: 2,
+        QcFlowStatusEnum.IN_PROGRESS.name: 11,
+        QcFlowStatusEnum.ON_HOLD.name: 3,
         QcFlowStatusEnum.QC_COMPLETE.name: 4,
     }
 
@@ -252,7 +253,9 @@ def test_paged_retrieval_for_statuses(
         assert paged_wells.page_size == 10
         assert paged_wells.page_number == 2
         assert paged_wells.total_number_of_items == total_number_of_items
-        assert len(paged_wells.wells) == 0
+        assert len(paged_wells.wells) == (
+            1 if status == QcFlowStatusEnum.IN_PROGRESS else 0
+        )
 
     status = QcFlowStatusEnum.QC_COMPLETE
     factory = PacBioPagedWellsFactory(

--- a/tests/test_wh_data_retrieval_pb.py
+++ b/tests/test_wh_data_retrieval_pb.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 import pytest
+from npg_id_generation.pac_bio import PacBioEntity
 from sqlalchemy import select
 
 from lang_qc.db.helper.wells import EmptyListOfRunNamesError, WellWh
@@ -59,11 +60,15 @@ def test_completed_wells_retrieval(mlwhdb_test_session, load_data4well_retrieval
 def test_well_metrics_retrieval(mlwhdb_test_session, load_data4well_retrieval):
 
     wm = WellWh(session=mlwhdb_test_session)
-    assert wm.get_well(run_name="UNKNOWN", well_label="A1") is None
-    assert wm.well_exists(run_name="UNKNOWN", well_label="A1") is False
 
-    wm = WellWh(session=mlwhdb_test_session)
-    well = wm.get_well(run_name="TRACTION_RUN_12", well_label="A1")
+    id_product = PacBioEntity(run_name="UNKNOWN", well_label="A1").hash_product_id()
+    assert wm.get_mlwh_well_by_product_id(id_product) is None
+
+    id_product = PacBioEntity(
+        run_name="TRACTION_RUN_12", well_label="A1"
+    ).hash_product_id()
+    well = wm.get_mlwh_well_by_product_id(id_product)
+    assert well.id_pac_bio_product == id_product
     assert well.pac_bio_run_name == "TRACTION_RUN_12"
     assert well.well_label == "A1"
     assert well.run_status == "None"
@@ -71,7 +76,6 @@ def test_well_metrics_retrieval(mlwhdb_test_session, load_data4well_retrieval):
     assert well.ccs_execution_mode == "OffInstrument"
     assert well.polymerase_num_reads == 3339714
     assert well.hifi_num_reads == 2226107
-    assert wm.well_exists(run_name="TRACTION_RUN_12", well_label="A1") is True
 
 
 def test_wells_in_runs_retrieval_boundary_cases(


### PR DESCRIPTION
Depends on https://github.com/wtsi-npg/npg_langqc/pull/171

Endpoint URLs are changed. Product ID, but no other
identifier, is embedded into the URLs. The database
helper is changed to reflect this change. It is also
extended to accommodate an extra identifier - the
plate number. Mapping of product IDs to run name,
well label and plate number is done via the mlwh,
records therefore creating QC records for entities
that are not present in mlwh becomes impossible.