### PR TITLE
QC states retrieval refactored, bug fixed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+* Tests for bulk retrieval of QC states
+
+### Fixed
+
+* A bug that disregarded the value of the `sequencing_outcomes_only`
+argument in what is now the `get_qc_states_by_id_product_list` function 
+
 ## [1.3.0] - 2023-08-02
 
 ### Added

--- a/lang_qc/db/helper/qc.py
+++ b/lang_qc/db/helper/qc.py
@@ -2,6 +2,7 @@
 #
 # Authors:
 #  Kieron Taylor <kt19@sanger.ac.uk>
+#  Marina Gourtovaia <mg8@sanger.ac.uk>
 #
 # This file is part of npg_langqc.
 #
@@ -18,86 +19,84 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Dict, List
-
-from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
 from lang_qc.db.qc_schema import QcState as QcStateDb
 from lang_qc.db.qc_schema import QcStateDict, QcType, SeqProduct, User
 from lang_qc.models.qc_state import QcState
+from lang_qc.util.type_checksum import ChecksumSHA256
 
 
-class BulkQcFetch(BaseModel):
+def get_qc_states_by_id_product_list(
+    session: Session,
+    ids: list[ChecksumSHA256],
+    sequencing_outcomes_only: bool = False,
+) -> dict[ChecksumSHA256, list[QcState]]:
+    """
+    Returns a dictionary whose keys are the given product IDs,
+    and the values are lists of QcState records of any type
+    for the same product.
 
-    session: Session = Field(
-        title="SQLAlchemy Session",
-        description="A SQLAlchemy Session for the LangQC database",
+    If only sequencing type QC states are required, an optional
+    argument, sequencing_outcomes_only, should be set to True.
+    If this case it is guaranteed that the list of QcState objects
+    has only one member.
+
+    Product IDs for which no QC states are available are omitted
+    from the response. The response may be an empty dictionary.
+
+    To remain efficient for large lists of product IDs, no input
+    validation is performed. The input should be validated by the
+    caller.
+    """
+
+    return _map_to_qc_state_models(
+        seq_products=_get_seq_product_by_id_list(session, ids),
+        sequencing_outcomes_only=sequencing_outcomes_only,
     )
 
-    class Config:
-        arbitrary_types_allowed = True
 
-    def query_by_id_list(
-        self, ids: List, sequencing_outcomes_only: bool = False
-    ) -> Dict[str, list[QcState]]:
-        """
-        Returns a dictionary whose keys are the given product IDs,
-        and the values are lists of QcState records of any type
-        for the same product.
-
-        If only sequencing type QC states are required, an optional
-        argument, sequencing_outcomes_only, should be set to True.
-
-        Product IDs for which no QC states are available are omitted
-        from the response. The response may be an empty dictionary.
-        """
-
-        seq_prods = self.get_qc_state_by_id_list(ids)
-        return self.extract_qc(
-            seq_products=seq_prods, sequencing_outcomes_only=sequencing_outcomes_only
-        )
-
-    def get_qc_state_by_id_list(self, ids) -> List[SeqProduct]:
-        """
-        Generates and executes a query for SeqProducts from a list
-        of product IDs. Prefetch all related QC states.
-        """
-        query = (
-            select(SeqProduct)
-            .join(QcStateDb)
-            .join(QcType)
-            .join(QcStateDict)
-            .join(User)
-            .where(SeqProduct.id_product.in_(ids))
-            .options(
-                selectinload(SeqProduct.qc_state).options(
-                    selectinload(QcStateDb.qc_type),
-                    selectinload(QcStateDb.user),
-                    selectinload(QcStateDb.qc_state_dict),
-                )
+def _get_seq_product_by_id_list(
+    session: Session, ids: list[ChecksumSHA256]
+) -> list[SeqProduct]:
+    """
+    Generates and executes a query for SeqProducts from a list
+    of product IDs. Prefetch all related QC states, types, etc.
+    """
+    query = (
+        select(SeqProduct)
+        .join(QcStateDb)
+        .join(QcType)
+        .join(QcStateDict)
+        .join(User)
+        .where(SeqProduct.id_product.in_(ids))
+        .options(
+            selectinload(SeqProduct.qc_state).options(
+                selectinload(QcStateDb.qc_type),
+                selectinload(QcStateDb.user),
+                selectinload(QcStateDb.qc_state_dict),
             )
         )
+    )
+    return session.execute(query).scalars().all()
 
-        return self.session.execute(query).scalars().all()
 
-    def extract_qc(
-        self, seq_products: List[SeqProduct], sequencing_outcomes_only: bool = False
-    ) -> Dict[str, Dict[str, QcState]]:
-        """
-        Given a list of SeqProducts, convert all related QC states into
-        QcState response format and hashes them by their product ID.
+def _map_to_qc_state_models(
+    seq_products: list[SeqProduct], sequencing_outcomes_only: bool = False
+) -> dict[ChecksumSHA256, list[QcState]]:
+    """
+    Given a list of SeqProducts, convert all related QC states into
+    QcState response format and hashes them by their product ID.
 
-        If only sequencing type QC states are required, an optional
-        argument, sequencing_outcomes_only, should be set to True.
-        """
-        response = dict()
-        for product in seq_products:
-            response[product.id_product] = []
-            for qc in product.qc_state:
-                if sequencing_outcomes_only and (qc.qc_type.qc_type != "sequencing"):
-                    pass
-                response[product.id_product].append(QcState.from_orm(qc))
-
-        return response
+    If only sequencing type QC states are required, an optional
+    argument, sequencing_outcomes_only, should be set to True.
+    """
+    response = dict()
+    for product in seq_products:
+        response[product.id_product] = []
+        for qc in product.qc_state:
+            if sequencing_outcomes_only and (qc.qc_type.qc_type != "sequencing"):
+                continue
+            response[product.id_product].append(QcState.from_orm(qc))
+    return response

--- a/lang_qc/endpoints/product.py
+++ b/lang_qc/endpoints/product.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from starlette import status
 
-from lang_qc.db.helper.qc import BulkQcFetch
+from lang_qc.db.helper.qc import get_qc_states_by_id_product_list
 from lang_qc.db.qc_connection import get_qc_db
 from lang_qc.models.qc_state import QcState
 from lang_qc.util.type_checksum import ChecksumSHA256
@@ -61,4 +61,4 @@ def bulk_qc_fetch(
     request_body: list[ChecksumSHA256], qcdb_session: Session = Depends(get_qc_db)
 ):
 
-    return BulkQcFetch(session=qcdb_session).query_by_id_list(request_body)
+    return get_qc_states_by_id_product_list(session=qcdb_session, ids=request_body)

--- a/lang_qc/models/pacbio/well.py
+++ b/lang_qc/models/pacbio/well.py
@@ -25,7 +25,7 @@ from typing import List
 from pydantic import BaseModel, Extra, Field
 from sqlalchemy.orm import Session
 
-from lang_qc.db.helper.qc import BulkQcFetch
+from lang_qc.db.helper.qc import get_qc_states_by_id_product_list
 from lang_qc.db.mlwh_schema import PacBioRunWellMetrics
 from lang_qc.models.pacbio.experiment import PacBioExperiment
 from lang_qc.models.pacbio.qc_data import QCDataWell
@@ -153,12 +153,10 @@ class PacBioWellFull(PacBioWell):
         if len(experiment_info):
             obj.experiment_tracking = PacBioExperiment.from_orm(experiment_info)
 
-        qced_products = (
-            BulkQcFetch(session=qc_session)
-            .query_by_id_list(ids=[id_product], sequencing_outcomes_only=True)
-            .get(id_product)
-        )
-        if (qced_products is not None) and len(qced_products) != 0:
+        qced_products = get_qc_states_by_id_product_list(
+            session=qc_session, ids=[id_product], sequencing_outcomes_only=True
+        ).get(id_product)
+        if qced_products is not None:
             obj.qc_state = qced_products[0]
 
         return obj

--- a/tests/test_qc_state_retrieval.py
+++ b/tests/test_qc_state_retrieval.py
@@ -1,0 +1,53 @@
+from lang_qc.db.helper.qc import get_qc_states_by_id_product_list
+from tests.fixtures.well_data import load_data4well_retrieval, load_dicts_and_users
+
+# "TRACTION_RUN_1", "D1", "On hold", Final
+FIRST_GOOD_CHECKSUM = "6657a34aa6159d7e2426f4732a84c51fa2d9186a4578e61ec21de4cb028fc800"
+# "TRACTION_RUN_2", "B1", "Failed, Instrument", Preliminary
+SECOND_GOOD_CHECKSUM = (
+    "e47765a207c810c2c281d5847e18c3015f3753b18bd92e8a2bea1219ba3127ea"
+)
+MISSING_CHECKSUM = "A" * 64
+
+
+def test_bulk_retrieval(qcdb_test_session, load_data4well_retrieval):
+
+    # The test below demonstrates that no run-time type checking of
+    # product IDs is performed.
+    assert get_qc_states_by_id_product_list(qcdb_test_session, ["dodo"]) == {}
+
+    two_good_ids_list = [FIRST_GOOD_CHECKSUM, SECOND_GOOD_CHECKSUM]
+    qc_state_descriptions = ["On hold", "Failed, Instrument"]
+
+    qc_states = get_qc_states_by_id_product_list(qcdb_test_session, two_good_ids_list)
+    assert len(qc_states) == 2
+    assert FIRST_GOOD_CHECKSUM in qc_states
+    assert SECOND_GOOD_CHECKSUM in qc_states
+    list_1 = qc_states[FIRST_GOOD_CHECKSUM]
+    list_2 = qc_states[SECOND_GOOD_CHECKSUM]
+    for index, l in enumerate([list_1, list_2]):
+        assert len(l) == 2
+        # The list of QC state objects contains QC states
+        # for different QC types.
+        assert {o.qc_type for o in l} == {"sequencing", "library"}
+        assert {o.qc_state for o in l} == {qc_state_descriptions[index]}
+
+    qc_states = get_qc_states_by_id_product_list(
+        session=qcdb_test_session, ids=two_good_ids_list, sequencing_outcomes_only=True
+    )
+    assert len(qc_states) == 2
+    assert FIRST_GOOD_CHECKSUM in qc_states
+    assert SECOND_GOOD_CHECKSUM in qc_states
+    list_1 = qc_states[FIRST_GOOD_CHECKSUM]
+    list_2 = qc_states[SECOND_GOOD_CHECKSUM]
+    for index, l in enumerate([list_1, list_2]):
+        assert len(l) == 1
+        assert l[0].qc_type == "sequencing"
+        assert l[0].qc_state == qc_state_descriptions[index]
+
+    qc_states = get_qc_states_by_id_product_list(
+        session=qcdb_test_session, ids=[SECOND_GOOD_CHECKSUM, MISSING_CHECKSUM]
+    )
+    assert len(qc_states) == 1
+    assert SECOND_GOOD_CHECKSUM in qc_states
+    assert MISSING_CHECKSUM not in qc_states


### PR DESCRIPTION
In future lang_qc/db/helper/qc.py will be used as a platform- independent retrieved of QC states for a single product or lists of products. The current designed is changed to pure functional since no state is associated with the proposed functionality.

Static type annotations are used to help with understanding input and output data.

All functions apart from the one used externally are converted to private. Tests are added for the only remaining public function.

A bug (incorrect implementation for the sequencing_outcomes_only flag) is fixed.

The module converted to pure functional