### PR TITLE
Increased the look-back period for inbox.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+* Increased the look-back period for the inbox query from 4 weeks to
+  12 weeks. Introduced a preliminary filtering by the QC state, which is
+  now available in ml warehouse. Since the ml warehouse QC state might not
+  be up-to-date, a final check against the LangQC database is retained.
+
 ## [1.4.1] - 2023-08-23
 
 ### Added

--- a/tests/test_wh_data_retrieval_pb.py
+++ b/tests/test_wh_data_retrieval_pb.py
@@ -17,8 +17,6 @@ def test_completed_wells_retrieval(mlwhdb_test_session, load_data4well_retrieval
         ["TRACTION_RUN_1", "B1"],
         ["TRACTION_RUN_1", "C1"],
         ["TRACTION_RUN_1", "D1"],
-        ["TRACTION_RUN_4", "A1"],
-        ["TRACTION_RUN_4", "B1"],
         ["TRACTION_RUN_4", "C1"],
         ["TRACTION_RUN_4", "D1"],
         ["TRACTION_RUN_3", "A1"],
@@ -42,7 +40,7 @@ def test_completed_wells_retrieval(mlwhdb_test_session, load_data4well_retrieval
         .scalars()
         .all()
     )
-    time = datetime.now() - timedelta(days=40)
+    time = datetime.now() - timedelta(days=130)
     for row in wells_to_update:
         if row.well_complete is not None:
             row.well_complete = time


### PR DESCRIPTION
Increased the look-back period for the inbox query from 4 weeks to 12 weeks. Added a preliminary filtering by the QC state, which is now available in mlwh. Since the mlwh QC state might not be up-to-date, a final check against the LangQC database is retained.