### PR TITLE
Fix the way vite runs in dev mode so that browser tools work

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -27,4 +27,4 @@ COPY ./vite.config.js /code/longue_vue/vite.config.js
 COPY ./index.html /code/longue_vue/index.html
 COPY ./.env /code/longue_vue/.env
 
-CMD ["npm", "exec", "vite", "--", "--host", "--port", "80", "--base", "/ui/"]
+CMD ["npm", "run", "dev", "--", "--host", "--port", "80", "--base", "/ui/"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,9 @@
     "npm": ">=8.11.0"
   },
   "scripts": {
-    "dev": "vite --port 3000",
+    "dev": "vite --port 80 --mode development",
     "build": "vite build",
-    "preview": "vite preview --port 3000",
+    "preview": "vite preview --port 80",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "test:e2e:ci": "start-server-and-test preview http://localhost:3000/ 'cypress run --e2e'",


### PR DESCRIPTION
Allows container run with `docker-compose --env-file $HOME/.env -f docker-compose.yml -f docker-compose.dev.yml up -d` to correctly ship unminified source to the browser.