### PR TITLE
Bug fixes to pool table

### DIFF
--- a/frontend/src/components/QcView.vue
+++ b/frontend/src/components/QcView.vue
@@ -18,22 +18,6 @@
         well: Object,
     })
 
-    const poolStats = ref(null)
-    watch(() => props.well, () => {
-        poolStats.value = null // empty in case next well doesn't have a pool
-        dataClient.getPoolMetrics(props.well.id_product).then(
-            (response) => { poolStats.value = response }
-        ).catch((error) => {
-            if (error.message.match("Conflict")) {
-                // Nothing to do
-            } else {
-                console.log(error)
-                // make a banner show this error?
-            }
-        })
-    }, { immediate: true}
-    )
-
     const slURL = computed(() => {
         let hostname = props.well.metrics.smrt_link.hostname
         let url = ''
@@ -118,6 +102,24 @@
         }
         return ''
     })
+
+    const poolStats = ref(null)
+    watch(() => props.well, () => {
+        poolStats.value = null // empty in case next well doesn't have a pool
+        if (ssLimsNumSamples.value > 0) {
+            dataClient.getPoolMetrics(props.well.id_product).then(
+                (response) => { poolStats.value = response }
+            ).catch((error) => {
+                if (error.message.match("Conflict")) {
+                    // Nothing to do
+                } else {
+                    console.log(error)
+                    // make a banner show this error?
+                }
+            })
+        }
+    }, { immediate: true }
+    )
 </script>
 
 <template>

--- a/frontend/src/stores/focusWell.js
+++ b/frontend/src/stores/focusWell.js
@@ -75,7 +75,7 @@ export const useWellStore = defineStore('focusWell', {
                 (error) => {
                     ElMessage({
                         message: error.message,
-                        type: error,
+                        type: "error",
                         duration: 5000
                     })
                 }

--- a/frontend/src/views/WellsByRun.vue
+++ b/frontend/src/views/WellsByRun.vue
@@ -36,7 +36,9 @@ function flatten_data(values) {
 getUserName((email) => { user.value = email }).then();
 
 watch(() => route.query, (after, before) => {
-    if (qcQueryChanged(before, after)) {
+    if (after.idProduct === undefined) {
+      focusWell.setFocusWell(null)
+    } else if (qcQueryChanged(before, after)) {
       focusWell.loadWellDetail(after.idProduct)
     }
   },

--- a/frontend/src/views/WellsByRun.vue
+++ b/frontend/src/views/WellsByRun.vue
@@ -53,6 +53,7 @@ watch(() => props.runName, () => {
   Promise.all(promises).then(
       (values) => (wellCollection.value = flatten_data(values))
   ).catch(error => {
+      console.log(error.message + " when resolving promises in props.runName watcher")
       ElMessage({
         message: error.message,
         type: "warning",

--- a/frontend/src/views/__tests__/WellsByRun.spec.js
+++ b/frontend/src/views/__tests__/WellsByRun.spec.js
@@ -138,7 +138,6 @@ describe('Does it work?', async () => {
     // Not providing precisely the right data, but serves for the component
     fetch.mockResponses(
       [JSON.stringify(secondaryRun)], // well QC data loading
-      [JSON.stringify({})] // Pool stats loading
     )
 
     let buttons = wrapper.findAll('button')
@@ -165,8 +164,9 @@ describe('Does it work?', async () => {
           page_number: 1,
           total_number_of_items: 1,
           wells: [secondaryRun]
-        })
-      ]
+        }),
+        { status: 200 }
+      ],
     )
     await wrapper.setProps({runName: ['TRACTION-RUN-211', 'TRACTION-RUN-210']})
     await flushPromises()

--- a/lang_qc/endpoints/pacbio_well.py
+++ b/lang_qc/endpoints/pacbio_well.py
@@ -236,7 +236,8 @@ def get_product_metrics(
         metrics = QCPoolMetrics(db_well=mlwh_well)
     except MissingLimsDataError:
         return
-
+    if len(metrics.products) == 0:
+        return
     return metrics
 
 

--- a/lang_qc/models/pacbio/qc_data.py
+++ b/lang_qc/models/pacbio/qc_data.py
@@ -238,7 +238,11 @@ class QCPoolMetrics:
                         tag1_name=lib_lims_data[i].tag_identifier,
                         tag2_name=lib_lims_data[i].tag2_identifier,
                         deplexing_barcode=prod.barcode4deplexing,
-                        hifi_read_bases=convert_to_gigabase(prod, "hifi_read_bases"),
+                        hifi_read_bases=(
+                            convert_to_gigabase(prod, "hifi_read_bases")
+                            if (prod.hifi_read_bases)
+                            else None
+                        ),
                         hifi_num_reads=prod.hifi_num_reads,
                         hifi_read_length_mean=prod.hifi_read_length_mean,
                         hifi_bases_percent=prod.hifi_bases_percent,

--- a/lang_qc/models/pacbio/qc_data.py
+++ b/lang_qc/models/pacbio/qc_data.py
@@ -227,7 +227,9 @@ class QCPoolMetrics:
                 cov = None
             else:
                 hifi_reads = [prod.hifi_num_reads for prod in product_metrics]
-                cov = round(stdev(hifi_reads) / mean(hifi_reads) * 100, 2)
+                if len(hifi_reads) > 1:
+                    # stdev throws on n=1
+                    cov = round(stdev(hifi_reads) / mean(hifi_reads) * 100, 2)
 
             for i, prod in enumerate(product_metrics):
                 sample_stats.append(


### PR DESCRIPTION
Stop sending response data when there are no products in `mlwh.pac_bio_product_metrics`, don't try to calculate stats on n=1, and make the client only request pool stats when we believe we have multiplexing.