### PR TITLE
Lift colours to app-level CSS so we can reuse in more tables.

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -173,4 +173,20 @@ nav {
   align-items: center;
   text-align: left;
 }
+
+.MetricOrange {
+  background-color: #F8CBAD;
+}
+
+.MetricBlue {
+  background-color: #BDD6EE;
+}
+
+.MetricGreen {
+  background-color: #C6E0B4;
+}
+
+.MetricYellow {
+  background-color: #FFE698;
+}
 </style>

--- a/frontend/src/components/PoolStats.vue
+++ b/frontend/src/components/PoolStats.vue
@@ -35,7 +35,7 @@ const active = ref([])
           <td>{{ library.hifi_num_reads }}</td>
           <td>{{ library.hifi_read_length_mean }}</td>
           <td>{{ library.hifi_bases_percent }}</td>
-          <td>{{ library.percentage_total_reads }}</td>
+          <td class="MetricYellow">{{ library.percentage_total_reads }}</td>
         </tr>
       </table>
     </el-collapse-item>


### PR DESCRIPTION
Highlighting desired reads per sample with pre-existing table colourings.
![Screenshot 2024-07-26 at 15 54 28](https://github.com/user-attachments/assets/16d50793-383c-47ad-816e-f9814fa82146)

I tried bold text, but it didn't look right as the only bold on the page